### PR TITLE
[10주차] 주간,월간 랭킹 (Spring Batch) - 김우철

### DIFF
--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/ranking/RankingAggregator.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/ranking/RankingAggregator.kt
@@ -1,10 +1,11 @@
-package com.loopers.domain.ranking
+package com.loopers.application.ranking
 
 import com.loopers.application.ranking.dto.RankingResult
 import com.loopers.domain.brand.Brand
 import com.loopers.domain.brand.BrandService
 import com.loopers.domain.product.Product
 import com.loopers.domain.product.ProductService
+import com.loopers.domain.ranking.RankingScore
 import org.springframework.stereotype.Component
 
 /**

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/ranking/RankingFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/ranking/RankingFacade.kt
@@ -2,6 +2,7 @@ package com.loopers.application.ranking
 
 import com.loopers.application.ranking.dto.RankingResult
 import com.loopers.domain.ranking.RankingAggregator
+import com.loopers.domain.ranking.RankingPeriod
 import com.loopers.domain.ranking.RankingService
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
@@ -16,27 +17,17 @@ class RankingFacade(
 ) {
 
     @Transactional(readOnly = true)
-    fun getRankings(date: String, pageable: Pageable): Page<RankingResult.RankedInfo> {
-        val dateKey = rankingService.parseDateKey(date)
-        val totalCount = rankingService.getTotalCount(dateKey)
+    fun getRankings(period: RankingPeriod, date: String, pageable: Pageable): Page<RankingResult.RankedInfo> {
+        val scorePage = rankingService.getRankingScores(period, date, pageable)
 
-        if (totalCount == 0L) {
-            return Page.empty(pageable)
-        }
-
-        if (pageable.offset >= totalCount) {
-            return PageImpl(emptyList(), pageable, totalCount)
-        }
-
-        val pageScores = rankingService.getPagedScores(dateKey, pageable.offset, pageable.pageSize)
-        if (pageScores.isEmpty()) {
-            return PageImpl(emptyList(), pageable, totalCount)
+        if (scorePage.isEmpty) {
+            return PageImpl(emptyList(), pageable, scorePage.totalElements)
         }
 
         val startRank = pageable.offset + 1L
-        val rankingItems = rankingAggregator.aggregate(pageScores, startRank)
+        val rankingItems = rankingAggregator.aggregate(scorePage.content, startRank)
 
-        return PageImpl(rankingItems, pageable, totalCount)
+        return PageImpl(rankingItems, pageable, scorePage.totalElements)
     }
 
     @Transactional(readOnly = true)

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/ranking/RankingFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/ranking/RankingFacade.kt
@@ -1,7 +1,6 @@
 package com.loopers.application.ranking
 
 import com.loopers.application.ranking.dto.RankingResult
-import com.loopers.domain.ranking.RankingAggregator
 import com.loopers.domain.ranking.RankingPeriod
 import com.loopers.domain.ranking.RankingService
 import org.springframework.data.domain.Page

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/ranking/ProductMonthlyRanking.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/ranking/ProductMonthlyRanking.kt
@@ -1,0 +1,47 @@
+package com.loopers.domain.ranking
+
+import com.loopers.infrastructure.converter.YearMonthAttributeConverter
+import jakarta.persistence.Column
+import jakarta.persistence.Convert
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.YearMonth
+import java.time.ZonedDateTime
+
+@Entity
+@Table(
+    name = "mv_product_rank_monthly",
+    indexes = [
+        Index(name = "idx_month_period", columnList = "month_period"),
+        Index(name = "idx_score", columnList = "score"),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(name = "uq_monthly_rank", columnNames = ["product_id", "month_period"]),
+    ],
+)
+class ProductMonthlyRanking(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "ranking", nullable = false)
+    val ranking: Int = 0,
+
+    @Column(name = "product_id", nullable = false)
+    val productId: Long = 0,
+
+    @Column(name = "score", nullable = false)
+    val score: Double = 0.0,
+
+    @Convert(converter = YearMonthAttributeConverter::class)
+    @Column(name = "month_period", nullable = false)
+    val monthPeriod: YearMonth,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: ZonedDateTime = ZonedDateTime.now(),
+)

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/ranking/ProductMonthlyRankingRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/ranking/ProductMonthlyRankingRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.domain.ranking
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import java.time.YearMonth
+
+interface ProductMonthlyRankingRepository {
+    fun findByMonthPeriod(monthPeriod: YearMonth, pageable: Pageable): Page<ProductMonthlyRanking>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/ranking/ProductWeeklyRanking.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/ranking/ProductWeeklyRanking.kt
@@ -1,0 +1,47 @@
+package com.loopers.domain.ranking
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.LocalDate
+import java.time.ZonedDateTime
+
+@Entity
+@Table(
+    name = "mv_product_rank_weekly",
+    indexes = [
+        Index(name = "idx_week", columnList = "week_start, week_end"),
+        Index(name = "idx_score", columnList = "score"),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(name = "uq_weekly_rank", columnNames = ["product_id", "week_start", "week_end"]),
+    ],
+)
+class ProductWeeklyRanking(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "ranking", nullable = false)
+    val ranking: Int = 0,
+
+    @Column(name = "product_id", nullable = false)
+    val productId: Long = 0,
+
+    @Column(name = "score", nullable = false)
+    val score: Double = 0.0,
+
+    @Column(name = "week_start", nullable = false)
+    val weekStart: LocalDate,
+
+    @Column(name = "week_end", nullable = false)
+    val weekEnd: LocalDate,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: ZonedDateTime = ZonedDateTime.now(),
+)

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/ranking/ProductWeeklyRankingRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/ranking/ProductWeeklyRankingRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.domain.ranking
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import java.time.LocalDate
+
+interface ProductWeeklyRankingRepository {
+    fun findByWeekRange(weekStart: LocalDate, weekEnd: LocalDate, pageable: Pageable): Page<ProductWeeklyRanking>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/ranking/RankingPeriod.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/ranking/RankingPeriod.kt
@@ -1,0 +1,22 @@
+package com.loopers.domain.ranking
+
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+
+enum class RankingPeriod {
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+    ;
+
+    companion object {
+        fun from(value: String?): RankingPeriod {
+            if (value.isNullOrBlank()) {
+                return DAILY
+            }
+
+            return entries.firstOrNull { it.name.equals(value, ignoreCase = true) }
+                ?: throw CoreException(ErrorType.BAD_REQUEST, "랭킹 기간 형식이 올바르지 않습니다: $value")
+        }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/ranking/RankingService.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/ranking/RankingService.kt
@@ -2,28 +2,48 @@ package com.loopers.domain.ranking
 
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import java.time.LocalDate
+import java.time.YearMonth
+import java.time.DayOfWeek
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
+import java.time.temporal.TemporalAdjusters
 
 @Service
 class RankingService(
     private val rankingRepository: RankingRepository,
+    private val productWeeklyRankingRepository: ProductWeeklyRankingRepository,
+    private val productMonthlyRankingRepository: ProductMonthlyRankingRepository,
 ) {
     companion object {
         private val DATE_KEY_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd")
     }
 
-    fun parseDateKey(date: String): String {
+    fun parseDateKey(date: String): String = parseDate(date).format(DATE_KEY_FORMATTER)
+
+    fun parseDate(date: String): LocalDate {
         return try {
-            LocalDate.parse(date, DATE_KEY_FORMATTER).format(DATE_KEY_FORMATTER)
+            LocalDate.parse(date, DATE_KEY_FORMATTER)
         } catch (e: DateTimeParseException) {
             throw CoreException(ErrorType.BAD_REQUEST, "랭킹 날짜 형식이 올바르지 않습니다: $date")
         }
     }
 
     fun todayDateKey(): String = LocalDate.now().format(DATE_KEY_FORMATTER)
+
+    fun getRankingScores(period: RankingPeriod, date: String, pageable: Pageable): Page<RankingScore> {
+        val parsedDate = parseDate(date)
+
+        return when (period) {
+            RankingPeriod.DAILY -> getDailyScores(parsedDate, pageable)
+            RankingPeriod.WEEKLY -> getWeeklyScores(parsedDate, pageable)
+            RankingPeriod.MONTHLY -> getMonthlyScores(parsedDate, pageable)
+        }
+    }
 
     fun getPagedScores(dateKey: String, offset: Long, size: Int): List<RankingScore> {
         if (offset < 0 || size <= 0) {
@@ -51,4 +71,44 @@ class RankingService(
     fun getTotalCount(dateKey: String): Long = rankingRepository.getTotalCount(dateKey)
 
     fun getRank(dateKey: String, productId: Long): Long? = rankingRepository.getRank(dateKey, productId)
+
+    private fun getDailyScores(date: LocalDate, pageable: Pageable): Page<RankingScore> {
+        val dateKey = date.format(DATE_KEY_FORMATTER)
+        val totalCount = getTotalCount(dateKey)
+
+        if (totalCount == 0L) {
+            return Page.empty(pageable)
+        }
+
+        if (pageable.offset >= totalCount) {
+            return PageImpl(emptyList(), pageable, totalCount)
+        }
+
+        val pageScores = getPagedScores(dateKey, pageable.offset, pageable.pageSize)
+        if (pageScores.isEmpty()) {
+            return PageImpl(emptyList(), pageable, totalCount)
+        }
+
+        return PageImpl(pageScores, pageable, totalCount)
+    }
+
+    private fun getWeeklyScores(date: LocalDate, pageable: Pageable): Page<RankingScore> {
+        val (weekStart, weekEnd) = weekRange(date)
+        val page = productWeeklyRankingRepository.findByWeekRange(weekStart, weekEnd, pageable)
+
+        return page.map { RankingScore(it.productId, it.score) }
+    }
+
+    private fun getMonthlyScores(date: LocalDate, pageable: Pageable): Page<RankingScore> {
+        val monthPeriod = YearMonth.from(date)
+        val page = productMonthlyRankingRepository.findByMonthPeriod(monthPeriod, pageable)
+
+        return page.map { RankingScore(it.productId, it.score) }
+    }
+
+    private fun weekRange(date: LocalDate): Pair<LocalDate, LocalDate> {
+        val start = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+        val end = date.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
+        return start to end
+    }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/converter/YearMonthAttributeConverter.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/converter/YearMonthAttributeConverter.kt
@@ -1,0 +1,17 @@
+package com.loopers.infrastructure.converter
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+import java.time.YearMonth
+
+@Converter(autoApply = true)
+class YearMonthAttributeConverter : AttributeConverter<YearMonth, String> {
+
+    override fun convertToDatabaseColumn(attribute: YearMonth?): String? {
+        return attribute?.toString() // "yyyy-MM"
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): YearMonth? {
+        return dbData?.let { YearMonth.parse(it) }
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/ranking/ProductMonthlyRankingJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/ranking/ProductMonthlyRankingJpaRepository.kt
@@ -1,0 +1,11 @@
+package com.loopers.infrastructure.ranking
+
+import com.loopers.domain.ranking.ProductMonthlyRanking
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.YearMonth
+
+interface ProductMonthlyRankingJpaRepository : JpaRepository<ProductMonthlyRanking, Long> {
+    fun findByMonthPeriod(monthPeriod: YearMonth, pageable: Pageable): Page<ProductMonthlyRanking>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/ranking/ProductMonthlyRankingRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/ranking/ProductMonthlyRankingRepositoryImpl.kt
@@ -15,7 +15,6 @@ class ProductMonthlyRankingRepositoryImpl(
 ) : ProductMonthlyRankingRepository {
 
     override fun findByMonthPeriod(monthPeriod: YearMonth, pageable: Pageable): Page<ProductMonthlyRanking> {
-        val sortedPageable = PageRequest.of(pageable.pageNumber, pageable.pageSize, Sort.by("ranking").ascending())
-        return productMonthlyRankingJpaRepository.findByMonthPeriod(monthPeriod, sortedPageable)
+        return productMonthlyRankingJpaRepository.findByMonthPeriod(monthPeriod, pageable)
     }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/ranking/ProductMonthlyRankingRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/ranking/ProductMonthlyRankingRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.loopers.infrastructure.ranking
+
+import com.loopers.domain.ranking.ProductMonthlyRanking
+import com.loopers.domain.ranking.ProductMonthlyRankingRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Repository
+import java.time.YearMonth
+
+@Repository
+class ProductMonthlyRankingRepositoryImpl(
+    private val productMonthlyRankingJpaRepository: ProductMonthlyRankingJpaRepository,
+) : ProductMonthlyRankingRepository {
+
+    override fun findByMonthPeriod(monthPeriod: YearMonth, pageable: Pageable): Page<ProductMonthlyRanking> {
+        val sortedPageable = PageRequest.of(pageable.pageNumber, pageable.pageSize, Sort.by("ranking").ascending())
+        return productMonthlyRankingJpaRepository.findByMonthPeriod(monthPeriod, sortedPageable)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/ranking/ProductWeeklyRankingJpaRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/ranking/ProductWeeklyRankingJpaRepository.kt
@@ -1,0 +1,11 @@
+package com.loopers.infrastructure.ranking
+
+import com.loopers.domain.ranking.ProductWeeklyRanking
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDate
+
+interface ProductWeeklyRankingJpaRepository : JpaRepository<ProductWeeklyRanking, Long> {
+    fun findByWeekStartAndWeekEnd(weekStart: LocalDate, weekEnd: LocalDate, pageable: Pageable): Page<ProductWeeklyRanking>
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/ranking/ProductWeeklyRankingRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/ranking/ProductWeeklyRankingRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.ranking
+
+import com.loopers.domain.ranking.ProductWeeklyRanking
+import com.loopers.domain.ranking.ProductWeeklyRankingRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+class ProductWeeklyRankingRepositoryImpl(
+    private val productWeeklyRankingJpaRepository: ProductWeeklyRankingJpaRepository,
+) : ProductWeeklyRankingRepository {
+
+    override fun findByWeekRange(
+        weekStart: LocalDate,
+        weekEnd: LocalDate,
+        pageable: Pageable,
+    ): Page<ProductWeeklyRanking> {
+        val sortedPageable = PageRequest.of(pageable.pageNumber, pageable.pageSize, Sort.by("ranking").ascending())
+        return productWeeklyRankingJpaRepository.findByWeekStartAndWeekEnd(weekStart, weekEnd, sortedPageable)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/v1/ranking/RankingV1ApiSpec.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/v1/ranking/RankingV1ApiSpec.kt
@@ -12,10 +12,12 @@ import org.springframework.data.domain.Pageable
 interface RankingV1ApiSpec {
     @Operation(
         summary = "랭킹 페이지 조회",
-        description = "일자별 상품 랭킹 페이지를 조회합니다.",
+        description = "기간과 날짜 기준 상품 랭킹 페이지를 조회합니다.",
     )
     fun getRankings(
-        @Parameter(description = "랭킹 날짜 (yyyyMMdd)")
+        @Parameter(description = "랭킹 기간 (daily, weekly, monthly)", schema = Schema(defaultValue = "daily"))
+        period: String,
+        @Parameter(description = "랭킹 기준 날짜 (yyyyMMdd), weekly는 해당 주, monthly는 해당 월 기준")
         date: String,
         @Parameter(description = "페이지 번호 (0부터 시작)", schema = Schema(defaultValue = "0"))
         pageable: Pageable,

--- a/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/v1/ranking/RankingV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/interfaces/api/v1/ranking/RankingV1Controller.kt
@@ -1,6 +1,7 @@
 package com.loopers.interfaces.api.v1.ranking
 
 import com.loopers.application.ranking.RankingFacade
+import com.loopers.domain.ranking.RankingPeriod
 import com.loopers.interfaces.api.ApiResponse
 import com.loopers.support.dto.PageResponse
 import org.springframework.data.domain.Pageable
@@ -18,10 +19,12 @@ class RankingV1Controller(
 
     @GetMapping
     override fun getRankings(
+        @RequestParam(required = false, defaultValue = "daily") period: String,
         @RequestParam date: String,
         @PageableDefault(size = 20) pageable: Pageable,
     ): ApiResponse<PageResponse<RankingV1Dto.RankingListResponse>> {
-        val rankingPage = rankingFacade.getRankings(date, pageable)
+        val rankingPeriod = RankingPeriod.from(period)
+        val rankingPage = rankingFacade.getRankings(rankingPeriod, date, pageable)
 
         return PageResponse.from(
             content = RankingV1Dto.RankingListResponse.from(rankingPage.content),

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/ranking/RankingServiceTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/ranking/RankingServiceTest.kt
@@ -18,7 +18,13 @@ import java.time.format.DateTimeFormatter
 class RankingServiceTest {
 
     private val rankingRepository: RankingRepository = mockk()
-    private val rankingService = RankingService(rankingRepository)
+    private val productWeeklyRankingRepository: ProductWeeklyRankingRepository = mockk()
+    private val productMonthlyRankingRepository: ProductMonthlyRankingRepository = mockk()
+    private val rankingService = RankingService(
+        rankingRepository,
+        productWeeklyRankingRepository,
+        productMonthlyRankingRepository,
+    )
 
     @Nested
     @DisplayName("parseDateKey 메서드는")

--- a/apps/commerce-api/src/test/kotlin/com/loopers/infrastructure/ranking/RankingRedisRepositoryOrderingTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/infrastructure/ranking/RankingRedisRepositoryOrderingTest.kt
@@ -26,7 +26,7 @@ class RankingRedisRepositoryOrderingTest : IntegrationTest() {
         val score = 10.0
 
         listOf(1L, 2L, 3L).forEach { productId ->
-            redisTemplate.opsForZSet().add(key, productId.toString(), score)
+            redisTemplate.opsForZSet().add(key, toMember(productId), score)
         }
 
         // when
@@ -47,7 +47,7 @@ class RankingRedisRepositoryOrderingTest : IntegrationTest() {
         val score = 5.0
 
         listOf(1L, 2L, 3L).forEach { productId ->
-            redisTemplate.opsForZSet().add(key, productId.toString(), score)
+            redisTemplate.opsForZSet().add(key, toMember(productId), score)
         }
 
         // when
@@ -59,5 +59,9 @@ class RankingRedisRepositoryOrderingTest : IntegrationTest() {
         assertThat(rank3).isEqualTo(0L)
         assertThat(rank2).isEqualTo(1L)
         assertThat(rank1).isEqualTo(2L)
+    }
+
+    private fun toMember(productId: Long): String {
+        return productId.toString().padStart(15, '0')
     }
 }

--- a/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/v1/ranking/RankingV1ApiTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/interfaces/api/v1/ranking/RankingV1ApiTest.kt
@@ -3,8 +3,12 @@ package com.loopers.interfaces.api.v1.ranking
 import com.loopers.ApiTest
 import com.loopers.domain.brand.Brand
 import com.loopers.domain.product.Product
+import com.loopers.domain.ranking.ProductMonthlyRanking
+import com.loopers.domain.ranking.ProductWeeklyRanking
 import com.loopers.infrastructure.brand.BrandJpaRepository
 import com.loopers.infrastructure.product.ProductJpaRepository
+import com.loopers.infrastructure.ranking.ProductMonthlyRankingJpaRepository
+import com.loopers.infrastructure.ranking.ProductWeeklyRankingJpaRepository
 import com.loopers.interfaces.api.ApiResponse
 import com.loopers.support.dto.PageResponse
 import com.loopers.utils.RedisCleanUp
@@ -16,12 +20,18 @@ import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.http.HttpMethod
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.temporal.TemporalAdjusters
 
 @DisplayName("Ranking V1 API 테스트")
 class RankingV1ApiTest(
     private val testRestTemplate: TestRestTemplate,
     private val brandJpaRepository: BrandJpaRepository,
     private val productJpaRepository: ProductJpaRepository,
+    private val productWeeklyRankingJpaRepository: ProductWeeklyRankingJpaRepository,
+    private val productMonthlyRankingJpaRepository: ProductMonthlyRankingJpaRepository,
     private val redisTemplate: RedisTemplate<String, String>,
     private val redisCleanUp: RedisCleanUp,
 ) : ApiTest() {
@@ -57,6 +67,96 @@ class RankingV1ApiTest(
         // then
         assertThat(response.statusCode.is2xxSuccessful).isTrue
         assertThat(response.body?.data?.pageInfo?.page).isEqualTo(0)
+        assertThat(response.body?.data?.content?.items?.firstOrNull()?.productId).isEqualTo(product1.id)
+    }
+
+    @Test
+    fun testGetWeeklyRankingsWhenPeriodIsWeeklyThenReturnsWeeklyRanking() {
+        // given
+        val brand = brandJpaRepository.save(Brand.create("loopers"))
+        val product1 = productJpaRepository.save(Product.create("item-1", 1000L, brand.id))
+        val product2 = productJpaRepository.save(Product.create("item-2", 900L, brand.id))
+
+        val dateKey = "20250115"
+        val date = LocalDate.parse(dateKey, java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd"))
+        val weekStart = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+        val weekEnd = date.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
+
+        productWeeklyRankingJpaRepository.save(
+            ProductWeeklyRanking(
+                ranking = 1,
+                productId = product1.id,
+                score = 10.0,
+                weekStart = weekStart,
+                weekEnd = weekEnd,
+            ),
+        )
+        productWeeklyRankingJpaRepository.save(
+            ProductWeeklyRanking(
+                ranking = 2,
+                productId = product2.id,
+                score = 9.0,
+                weekStart = weekStart,
+                weekEnd = weekEnd,
+            ),
+        )
+
+        val responseType = object :
+            ParameterizedTypeReference<ApiResponse<PageResponse<RankingV1Dto.RankingListResponse>>>() {}
+
+        // when
+        val response = testRestTemplate.exchange(
+            "/api/v1/rankings?period=weekly&date=$dateKey&size=1&page=0",
+            HttpMethod.GET,
+            null,
+            responseType,
+        )
+
+        // then
+        assertThat(response.statusCode.is2xxSuccessful).isTrue
+        assertThat(response.body?.data?.content?.items?.firstOrNull()?.productId).isEqualTo(product1.id)
+    }
+
+    @Test
+    fun testGetMonthlyRankingsWhenPeriodIsMonthlyThenReturnsMonthlyRanking() {
+        // given
+        val brand = brandJpaRepository.save(Brand.create("loopers"))
+        val product1 = productJpaRepository.save(Product.create("item-1", 1000L, brand.id))
+        val product2 = productJpaRepository.save(Product.create("item-2", 900L, brand.id))
+
+        val dateKey = "20250115"
+        val monthPeriod = YearMonth.of(2025, 1)
+
+        productMonthlyRankingJpaRepository.save(
+            ProductMonthlyRanking(
+                ranking = 1,
+                productId = product1.id,
+                score = 10.0,
+                monthPeriod = monthPeriod,
+            ),
+        )
+        productMonthlyRankingJpaRepository.save(
+            ProductMonthlyRanking(
+                ranking = 2,
+                productId = product2.id,
+                score = 9.0,
+                monthPeriod = monthPeriod,
+            ),
+        )
+
+        val responseType = object :
+            ParameterizedTypeReference<ApiResponse<PageResponse<RankingV1Dto.RankingListResponse>>>() {}
+
+        // when
+        val response = testRestTemplate.exchange(
+            "/api/v1/rankings?period=monthly&date=$dateKey&size=1&page=0",
+            HttpMethod.GET,
+            null,
+            responseType,
+        )
+
+        // then
+        assertThat(response.statusCode.is2xxSuccessful).isTrue
         assertThat(response.body?.data?.content?.items?.firstOrNull()?.productId).isEqualTo(product1.id)
     }
 }

--- a/apps/commerce-batch/build.gradle.kts
+++ b/apps/commerce-batch/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    id("org.jetbrains.kotlin.plugin.jpa")
+}
+
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-batch")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // querydsl
+    kapt("com.querydsl:querydsl-apt::jakarta")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+}

--- a/apps/commerce-batch/build.gradle.kts
+++ b/apps/commerce-batch/build.gradle.kts
@@ -10,11 +10,15 @@ dependencies {
     implementation(project(":supports:monitoring"))
 
     // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-batch")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 
     // querydsl
     kapt("com.querydsl:querydsl-apt::jakarta")
+
+    // test
+    testImplementation("org.springframework.batch:spring-batch-test")
 
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/CommerceBatchApplication.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/CommerceBatchApplication.kt
@@ -1,0 +1,22 @@
+package com.loopers
+
+import jakarta.annotation.PostConstruct
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
+import java.util.TimeZone
+
+@ConfigurationPropertiesScan
+@SpringBootApplication
+class CommerceBatchApplication {
+
+    @PostConstruct
+    fun started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
+    }
+}
+
+fun main(args: Array<String>) {
+    runApplication<CommerceBatchApplication>(*args)
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/BatchJobController.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/BatchJobController.kt
@@ -1,0 +1,62 @@
+package com.loopers.batch
+
+import com.loopers.batch.productmetrics.ranking.ProductWeeklyRankingJobConfig
+import org.springframework.batch.core.Job
+import org.springframework.batch.core.JobParametersBuilder
+import org.springframework.batch.core.launch.JobLauncher
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 배치 Job 실행 API 컨트롤러
+ *
+ * 배치 작업을 수동으로 실행할 수 있는 REST API 제공
+ */
+@RestController
+@RequestMapping("/api/v1/batch")
+class BatchJobController(
+    private val jobLauncher: JobLauncher,
+    @Qualifier(ProductWeeklyRankingJobConfig.JOB_NAME)
+    private val productWeeklyRankingJob: Job,
+) {
+
+    /**
+     * 주간 상품 랭킹 배치 실행
+     *
+     * @param weekStart 주 시작일 (yyyy-MM-dd 형식, 필수)
+     * @param weekEnd 주 종료일 (yyyy-MM-dd 형식, 필수)
+     *
+     * 예시:
+     * - POST /api/v1/batch/weekly-ranking?weekStart=2025-01-06&weekEnd=2025-01-12
+     */
+    @PostMapping("/weekly-ranking")
+    fun runWeeklyRanking(
+        @RequestParam weekStart: String,
+        @RequestParam weekEnd: String,
+    ): ResponseEntity<Map<String, Any>> {
+        // Job 파라미터 생성
+        val params = JobParametersBuilder()
+            .addString("weekStart", weekStart)
+            .addString("weekEnd", weekEnd)
+            .addLong("timestamp", System.currentTimeMillis())
+            .toJobParameters()
+
+        // Job 실행
+        val execution = jobLauncher.run(productWeeklyRankingJob, params)
+
+        return ResponseEntity.ok(
+            mapOf(
+                "jobName" to ProductWeeklyRankingJobConfig.JOB_NAME,
+                "jobId" to execution.jobId,
+                "status" to execution.status.name,
+                "weekStart" to weekStart,
+                "weekEnd" to weekEnd,
+                "startTime" to execution.startTime,
+            ),
+        )
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/BatchJobController.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/BatchJobController.kt
@@ -31,6 +31,10 @@ class BatchJobController(
     /**
      * 주간 상품 랭킹 배치 실행
      *
+     * 실행 시점(월~일 기준):
+     * - 해당 주간이 끝난 뒤(일요일 종료 이후), 집계 데이터가 모두 적재된 다음 실행
+     * - 일반적으로 다음 주 월요일 00:00 이후 실행 권장
+     *
      * @param weekStart 주 시작일 (yyyy-MM-dd 형식, 필수)
      * @param weekEnd 주 종료일 (yyyy-MM-dd 형식, 필수)
      *
@@ -66,6 +70,10 @@ class BatchJobController(
 
     /**
      * 월별 상품 랭킹 배치 실행
+     *
+     * 실행 시점:
+     * - 해당 월이 끝난 뒤, 그 월을 포함하는 마지막 주간 랭킹이 생성된 다음 실행
+     * - 일반적으로 다음 달 1일 00:00 이후 실행 권장
      *
      * @param yearMonth 월 (yyyy-MM 형식, 필수)
      *

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingJobConfig.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingJobConfig.kt
@@ -19,7 +19,7 @@ import org.springframework.transaction.PlatformTransactionManager
  * - Step: PRODUCT_MONTHLY_RANKING_STEP
  * - Chunk 크기: 1,000개
  * - 흐름: Reader -> Writer
- *   - Reader: 주간 랭킹 데이터를 월 단위로 집계하여 RankedProduct 반환
+ *   - Reader: product_metrics를 월 단위로 집계하여 RankedProduct 반환
  *   - Writer: Top 100을 ProductMonthlyRankingRepository에 저장
  */
 @Configuration

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingJobConfig.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingJobConfig.kt
@@ -1,0 +1,58 @@
+package com.loopers.batch.productmetrics.ranking
+
+import com.loopers.domain.ranking.dto.RankedProduct
+import org.springframework.batch.core.Job
+import org.springframework.batch.core.Step
+import org.springframework.batch.core.job.builder.JobBuilder
+import org.springframework.batch.core.repository.JobRepository
+import org.springframework.batch.core.step.builder.StepBuilder
+import org.springframework.batch.item.database.JdbcPagingItemReader
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.transaction.PlatformTransactionManager
+
+/**
+ * 월간 상품 랭킹 집계 Job 설정
+ *
+ * - Job: PRODUCT_MONTHLY_RANKING_JOB
+ * - Step: PRODUCT_MONTHLY_RANKING_STEP
+ * - Chunk 크기: 1,000개
+ * - 흐름: Reader -> Writer
+ *   - Reader: 주간 랭킹 데이터를 월 단위로 집계하여 RankedProduct 반환
+ *   - Writer: Top 100을 ProductMonthlyRankingRepository에 저장
+ */
+@Configuration
+class ProductMonthlyRankingJobConfig(
+    private val jobRepository: JobRepository,
+    private val transactionManager: PlatformTransactionManager,
+) {
+
+    @Bean(name = [JOB_NAME])
+    fun productMonthlyRankingJob(
+        @Qualifier(STEP_NAME) step: Step,
+    ): Job {
+        return JobBuilder(JOB_NAME, jobRepository)
+            .preventRestart()
+            .start(step)
+            .build()
+    }
+
+    @Bean(name = [STEP_NAME])
+    fun productMonthlyRankingStep(
+        @Qualifier("monthlyRankingReader") productMonthlyRankingReader: JdbcPagingItemReader<RankedProduct>,
+        productMonthlyRankingWriter: ProductMonthlyRankingWriter,
+    ): Step {
+        return StepBuilder(STEP_NAME, jobRepository)
+            .chunk<RankedProduct, RankedProduct>(CHUNK_SIZE, transactionManager)
+            .reader(productMonthlyRankingReader)
+            .writer(productMonthlyRankingWriter)
+            .build()
+    }
+
+    companion object {
+        const val JOB_NAME = "PRODUCT_MONTHLY_RANKING_JOB"
+        const val STEP_NAME = "PRODUCT_MONTHLY_RANKING_STEP"
+        const val CHUNK_SIZE = 1_000
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingJobConfig.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingJobConfig.kt
@@ -53,6 +53,6 @@ class ProductMonthlyRankingJobConfig(
     companion object {
         const val JOB_NAME = "PRODUCT_MONTHLY_RANKING_JOB"
         const val STEP_NAME = "PRODUCT_MONTHLY_RANKING_STEP"
-        const val CHUNK_SIZE = 1_000
+        const val CHUNK_SIZE = 100
     }
 }

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingProcessor.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingProcessor.kt
@@ -1,0 +1,36 @@
+package com.loopers.batch.productmetrics.ranking
+
+import com.loopers.domain.ranking.dto.ProductMonthlyMetricsAggregate
+import com.loopers.domain.ranking.dto.RankedProduct
+import org.springframework.batch.core.configuration.annotation.StepScope
+import org.springframework.batch.item.ItemProcessor
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+/**
+ * 월간 상품 랭킹 Processor
+ *
+ * ProductMetricsAggregate를 받아서 가중치를 적용하여 RankedProduct로 변환
+ *
+ * 가중치 공식:
+ * - 조회수 * viewWeight + 주문수 * soldWeight + 좋아요 * likeWeight
+ */
+@Component
+@StepScope
+class ProductMonthlyRankingProcessor(
+    @Value("\${batch.ranking.weights.view}") private val viewWeight: Double,
+    @Value("\${batch.ranking.weights.like}") private val likeWeight: Double,
+    @Value("\${batch.ranking.weights.sold}") private val soldWeight: Double,
+) : ItemProcessor<ProductMonthlyMetricsAggregate, RankedProduct> {
+
+    override fun process(item: ProductMonthlyMetricsAggregate): RankedProduct {
+        val finalScore = item.totalViewCount * viewWeight +
+                item.totalSoldCount * soldWeight +
+                item.totalLikeCount * likeWeight
+
+        return RankedProduct(
+            productId = item.productId,
+            finalScore = finalScore,
+        )
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingReader.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingReader.kt
@@ -47,10 +47,7 @@ class ProductMonthlyRankingReader {
 
         val fromClause = "FROM product_metrics"
 
-        val whereClause = """
-            WHERE metric_date BETWEEN :monthStart AND :monthEnd
-            GROUP BY product_id
-        """.trimIndent()
+        val whereClause = "WHERE metric_date BETWEEN :monthStart AND :monthEnd"
 
         val sortKey = mapOf("final_score" to Order.DESCENDING)
 
@@ -69,6 +66,7 @@ class ProductMonthlyRankingReader {
                     setSelectClause(selectClause)
                     setFromClause(fromClause)
                     setWhereClause(whereClause)
+                    setGroupClause("product_id")
                     sortKeys = sortKey
                 },
             )
@@ -79,7 +77,7 @@ class ProductMonthlyRankingReader {
                     "monthEnd" to monthEnd,
                 ),
             )
-            .pageSize(1000)
+            .pageSize(100)
             .rowMapper(rowMapper)
             .saveState(true)
             .build()

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingReader.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingReader.kt
@@ -1,6 +1,6 @@
 package com.loopers.batch.productmetrics.ranking
 
-import com.loopers.domain.ranking.dto.RankedProduct
+import com.loopers.domain.ranking.dto.ProductMonthlyMetricsAggregate
 import org.springframework.batch.core.configuration.annotation.StepScope
 import org.springframework.batch.item.database.JdbcPagingItemReader
 import org.springframework.batch.item.database.Order
@@ -16,7 +16,7 @@ import javax.sql.DataSource
 /**
  * 월간 상품 메트릭 Reader
  *
- * product_metrics를 월 단위로 집계하여 productId별 점수를 반환
+ * product_metrics를 월 단위로 집계하여 productId별 원본 메트릭을 반환
  */
 @Configuration
 class ProductMonthlyRankingReader {
@@ -26,39 +26,37 @@ class ProductMonthlyRankingReader {
     fun monthlyRankingReader(
         dataSource: DataSource,
         @Value("#{jobParameters['yearMonth']}") yearMonth: String,
-        @Value("\${batch.ranking.weights.view}") viewWeight: Double,
-        @Value("\${batch.ranking.weights.like}") likeWeight: Double,
-        @Value("\${batch.ranking.weights.sold}") soldWeight: Double,
-    ): JdbcPagingItemReader<RankedProduct> {
+    ): JdbcPagingItemReader<ProductMonthlyMetricsAggregate> {
         val month = YearMonth.parse(yearMonth)
         val monthStart = month.atDay(1)
         val monthEnd = month.atEndOfMonth()
 
-        // 월 범위 내 일자별 메트릭을 합산
+        // 월 범위 내 일자별 메트릭을 합산 (원본 값만)
         val selectClause = """
             SELECT
                 product_id,
-                SUM(
-                    view_count * $viewWeight +
-                    like_count * $likeWeight +
-                    sold_count * $soldWeight
-                ) as final_score
+                SUM(view_count) as total_view_count,
+                SUM(like_count) as total_like_count,
+                SUM(sold_count) as total_sold_count
         """.trimIndent()
 
         val fromClause = "FROM product_metrics"
 
         val whereClause = "WHERE metric_date BETWEEN :monthStart AND :monthEnd"
 
-        val sortKey = mapOf("final_score" to Order.DESCENDING)
+        // 임시 정렬 키 (Processor에서 점수 계산 후 재정렬됨)
+        val sortKey = mapOf("product_id" to Order.ASCENDING)
 
         val rowMapper = RowMapper { rs, _ ->
-            RankedProduct(
+            ProductMonthlyMetricsAggregate(
                 productId = rs.getLong("product_id"),
-                finalScore = rs.getDouble("final_score"),
+                totalViewCount = rs.getLong("total_view_count"),
+                totalLikeCount = rs.getLong("total_like_count"),
+                totalSoldCount = rs.getLong("total_sold_count"),
             )
         }
 
-        return JdbcPagingItemReaderBuilder<RankedProduct>()
+        return JdbcPagingItemReaderBuilder<ProductMonthlyMetricsAggregate>()
             .name("productMonthlyRankingReader")
             .dataSource(dataSource)
             .queryProvider(
@@ -66,7 +64,7 @@ class ProductMonthlyRankingReader {
                     setSelectClause(selectClause)
                     setFromClause(fromClause)
                     setWhereClause(whereClause)
-                    setGroupClause("product_id")
+                    groupClause = "product_id"
                     sortKeys = sortKey
                 },
             )

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingReader.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingReader.kt
@@ -1,0 +1,81 @@
+package com.loopers.batch.productmetrics.ranking
+
+import com.loopers.domain.ranking.dto.RankedProduct
+import org.springframework.batch.core.configuration.annotation.StepScope
+import org.springframework.batch.item.database.JdbcPagingItemReader
+import org.springframework.batch.item.database.Order
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder
+import org.springframework.batch.item.database.support.MySqlPagingQueryProvider
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.core.RowMapper
+import java.time.YearMonth
+import javax.sql.DataSource
+
+/**
+ * 월간 상품 메트릭 Reader
+ *
+ * 주간 랭킹 데이터를 월 단위로 합산하여 productId별 점수를 반환
+ */
+@Configuration
+class ProductMonthlyRankingReader {
+
+    @Bean
+    @StepScope
+    fun monthlyRankingReader(
+        dataSource: DataSource,
+        @Value("#{jobParameters['yearMonth']}") yearMonth: String,
+    ): JdbcPagingItemReader<RankedProduct> {
+        val month = YearMonth.parse(yearMonth)
+        val monthStart = month.atDay(1)
+        val monthEnd = month.atEndOfMonth()
+
+        // 주간 집계 MV를 월 범위로 덮어 합산
+        val selectClause = """
+            SELECT
+                product_id,
+                SUM(score) as final_score
+        """.trimIndent()
+
+        val fromClause = "FROM mv_product_rank_weekly"
+
+        val whereClause = """
+            WHERE week_start <= :monthEnd
+              AND week_end >= :monthStart
+            GROUP BY product_id
+        """.trimIndent()
+
+        val sortKey = mapOf("final_score" to Order.DESCENDING)
+
+        val rowMapper = RowMapper { rs, _ ->
+            RankedProduct(
+                productId = rs.getLong("product_id"),
+                finalScore = rs.getDouble("final_score"),
+            )
+        }
+
+        return JdbcPagingItemReaderBuilder<RankedProduct>()
+            .name("productMonthlyRankingReader")
+            .dataSource(dataSource)
+            .queryProvider(
+                MySqlPagingQueryProvider().apply {
+                    setSelectClause(selectClause)
+                    setFromClause(fromClause)
+                    setWhereClause(whereClause)
+                    sortKeys = sortKey
+                },
+            )
+            .parameterValues(
+                mapOf(
+                    // 월 경계는 LocalDate로 바인딩
+                    "monthStart" to monthStart,
+                    "monthEnd" to monthEnd,
+                ),
+            )
+            .pageSize(1000)
+            .rowMapper(rowMapper)
+            .saveState(true)
+            .build()
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingWriter.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingWriter.kt
@@ -65,6 +65,7 @@ class ProductMonthlyRankingWriter(
         val sql = """
             INSERT INTO temp_monthly_ranking (product_id, score)
             VALUES (?, ?)
+            ON DUPLICATE KEY UPDATE score = score + VALUES(score)
         """.trimIndent()
 
         jdbcTemplate.batchUpdate(

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingWriter.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingWriter.kt
@@ -4,80 +4,139 @@ import com.loopers.domain.ranking.ProductMonthlyRanking
 import com.loopers.domain.ranking.ProductMonthlyRankingRepository
 import com.loopers.domain.ranking.dto.RankedProduct
 import org.slf4j.LoggerFactory
+import org.springframework.batch.core.StepExecution
+import org.springframework.batch.core.annotation.AfterStep
+import org.springframework.batch.core.annotation.BeforeStep
 import org.springframework.batch.core.configuration.annotation.StepScope
 import org.springframework.batch.item.Chunk
 import org.springframework.batch.item.ItemWriter
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.YearMonth
 
 /**
  * 월간 상품 랭킹 Writer
  *
- * RankedProduct를 받아서 productId별로 점수를 합산하고 Top 100을 저장
+ * RankedProduct를 받아서 임시 테이블에 누적하고, AfterStep에서 점수순으로 정렬하여 Top 100을 저장
+ *
+ * 메모리 사용량을 최소화하기 위해 임시 테이블(temp_monthly_ranking)을 활용:
+ * 1. BeforeStep: 임시 테이블 생성 및 기존 데이터 삭제
+ * 2. write(): 청크 단위로 임시 테이블에 INSERT
+ * 3. AfterStep: 임시 테이블에서 Top 100 추출 후 저장
  */
 @Component
 @StepScope
 class ProductMonthlyRankingWriter(
+    private val jdbcTemplate: JdbcTemplate,
     private val repository: ProductMonthlyRankingRepository,
+    private val transactionTemplate: TransactionTemplate,
     @Value("#{jobParameters['yearMonth']}") private val yearMonth: String,
 ) : ItemWriter<RankedProduct> {
 
     private val log = LoggerFactory.getLogger(ProductMonthlyRankingWriter::class.java)
-    // State kept across chunks to build a single Top 100 list.
-    private var initialized = false
-    private var rankCounter = 0
 
-    @Transactional
+    @BeforeStep
+    fun beforeStep(stepExecution: StepExecution) {
+        // 임시 테이블 생성 (이미 존재하면 재사용)
+        jdbcTemplate.execute(
+            """
+            CREATE TEMPORARY TABLE IF NOT EXISTS temp_monthly_ranking (
+                product_id BIGINT NOT NULL,
+                score DOUBLE NOT NULL DEFAULT 0,
+                PRIMARY KEY (product_id)
+            )
+            """.trimIndent(),
+        )
+
+        // 임시 테이블 초기화 (이전 실행 데이터 제거)
+        jdbcTemplate.execute("TRUNCATE TABLE temp_monthly_ranking")
+
+        log.info("Initialized temp_monthly_ranking table")
+    }
+
     override fun write(chunk: Chunk<out RankedProduct>) {
-        val items = chunk.items
-
-        if (items.isEmpty()) {
+        if (chunk.isEmpty) {
             return
         }
 
-        // Job 파라미터를 월 단위로 파싱
+        // 임시 테이블에 청크 데이터 삽입
+        val sql = """
+            INSERT INTO temp_monthly_ranking (product_id, score)
+            VALUES (?, ?)
+        """.trimIndent()
+
+        jdbcTemplate.batchUpdate(
+            sql,
+            chunk.items,
+            chunk.size(),
+        ) { ps, item ->
+            ps.setLong(1, item.productId)
+            ps.setDouble(2, item.finalScore)
+        }
+
+        log.debug("Inserted {} products into temp_monthly_ranking", chunk.size())
+    }
+
+    @AfterStep
+    fun afterStep(stepExecution: StepExecution) {
+        if (stepExecution.exitStatus.exitCode != "COMPLETED") {
+            log.warn("Step did not complete successfully. Skipping monthly ranking save.")
+            return
+        }
+
         val monthPeriod = YearMonth.parse(yearMonth)
 
-        if (!initialized) {
-            // 동일 월 데이터는 삭제 후 재적재하여 멱등성 확보
-            repository.deleteByMonthPeriod(monthPeriod)
-            initialized = true
-        }
+        // 임시 테이블에서 총 상품 수 확인
+        val totalProducts = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM temp_monthly_ranking",
+            Long::class.java,
+        ) ?: 0L
 
-        // Reader가 점수 내림차순 정렬을 보장하므로 Top 100까지만 순차 저장.
-        if (rankCounter >= 100) {
+        if (totalProducts == 0L) {
+            log.warn("No ranked products to save")
             return
         }
 
-        val entities = mutableListOf<ProductMonthlyRanking>()
-        for (rankedProduct in items) {
-            if (rankCounter >= 100) {
-                break
-            }
-
-            rankCounter += 1
-            entities.add(
-                ProductMonthlyRanking.create(
-                    ranking = rankCounter,
-                    productId = rankedProduct.productId,
-                    score = rankedProduct.finalScore,
-                    monthPeriod = monthPeriod,
-                ),
+        // 임시 테이블에서 Top 100 추출 (점수 내림차순)
+        val top100 = jdbcTemplate.query(
+            """
+            SELECT
+                product_id,
+                score,
+                ROW_NUMBER() OVER (ORDER BY score DESC) as ranking
+            FROM temp_monthly_ranking
+            ORDER BY score DESC
+            LIMIT 100
+            """.trimIndent(),
+        ) { rs, _ ->
+            ProductMonthlyRanking.create(
+                ranking = rs.getInt("ranking"),
+                productId = rs.getLong("product_id"),
+                score = rs.getDouble("score"),
+                monthPeriod = monthPeriod,
             )
         }
 
-        if (entities.isEmpty()) {
-            return
+        // 트랜잭션 내에서 삭제 및 저장 작업 수행
+        transactionTemplate.execute {
+            // 동일 월 데이터는 삭제 후 재적재하여 멱등성 확보
+            repository.deleteByMonthPeriod(monthPeriod)
+
+            // Top 100 저장
+            repository.saveAll(top100)
         }
 
-        repository.saveAll(entities)
-
         log.info(
-            "Saved {} monthly rankings (Top 100) for month {}",
-            entities.size,
+            "Saved Top {} monthly rankings for month {} (total products: {})",
+            top100.size,
             monthPeriod,
+            totalProducts,
         )
+
+        // 임시 테이블 정리
+        jdbcTemplate.execute("DROP TEMPORARY TABLE IF EXISTS temp_monthly_ranking")
+        log.debug("Dropped temp_monthly_ranking table")
     }
 }

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingWriter.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductMonthlyRankingWriter.kt
@@ -1,0 +1,65 @@
+package com.loopers.batch.productmetrics.ranking
+
+import com.loopers.domain.ranking.ProductMonthlyRanking
+import com.loopers.domain.ranking.ProductMonthlyRankingRepository
+import com.loopers.domain.ranking.dto.RankedProduct
+import org.slf4j.LoggerFactory
+import org.springframework.batch.core.configuration.annotation.StepScope
+import org.springframework.batch.item.Chunk
+import org.springframework.batch.item.ItemWriter
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.YearMonth
+
+/**
+ * 월간 상품 랭킹 Writer
+ *
+ * RankedProduct를 받아서 productId별로 점수를 합산하고 Top 100을 저장
+ */
+@Component
+@StepScope
+class ProductMonthlyRankingWriter(
+    private val repository: ProductMonthlyRankingRepository,
+    @Value("#{jobParameters['yearMonth']}") private val yearMonth: String,
+) : ItemWriter<RankedProduct> {
+
+    private val log = LoggerFactory.getLogger(ProductMonthlyRankingWriter::class.java)
+
+    @Transactional
+    override fun write(chunk: Chunk<out RankedProduct>) {
+        val items = chunk.items
+
+        if (items.isEmpty()) {
+            return
+        }
+
+        // Job 파라미터를 월 단위로 파싱
+        val monthPeriod = YearMonth.parse(yearMonth)
+
+        // 점수 기준 Top 100만 유지
+        val top100 = items
+            .sortedByDescending { it.finalScore }
+            .take(100)
+
+        // 동일 월 데이터는 삭제 후 재적재하여 멱등성 확보
+        repository.deleteByMonthPeriod(monthPeriod)
+
+        val entities = top100.mapIndexed { index, rankedProduct ->
+            ProductMonthlyRanking.create(
+                ranking = index + 1,
+                productId = rankedProduct.productId,
+                score = rankedProduct.finalScore,
+                monthPeriod = monthPeriod,
+            )
+        }
+
+        repository.saveAll(entities)
+
+        log.info(
+            "Saved {} monthly rankings (Top 100) for month {}",
+            entities.size,
+            monthPeriod,
+        )
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingJobConfig.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingJobConfig.kt
@@ -40,7 +40,7 @@ class ProductWeeklyRankingJobConfig(
 
     @Bean(name = [STEP_NAME])
     fun productWeeklyRankingStep(
-        productWeeklyRankingReader: JdbcPagingItemReader<RankedProduct>,
+        @Qualifier("weeklyRankingReader") productWeeklyRankingReader: JdbcPagingItemReader<RankedProduct>,
         productWeeklyRankingWriter: ProductWeeklyRankingWriter,
     ): Step {
         return StepBuilder(STEP_NAME, jobRepository)

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingJobConfig.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingJobConfig.kt
@@ -1,0 +1,58 @@
+package com.loopers.batch.productmetrics.ranking
+
+import com.loopers.domain.ranking.dto.RankedProduct
+import org.springframework.batch.core.Job
+import org.springframework.batch.core.Step
+import org.springframework.batch.core.job.builder.JobBuilder
+import org.springframework.batch.core.repository.JobRepository
+import org.springframework.batch.core.step.builder.StepBuilder
+import org.springframework.batch.item.database.JdbcPagingItemReader
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.transaction.PlatformTransactionManager
+
+/**
+ * 주간 상품 랭킹 집계 Job 설정
+ *
+ * - Job: PRODUCT_WEEKLY_RANKING_JOB
+ * - Step: PRODUCT_WEEKLY_RANKING_STEP
+ * - Chunk 크기: 1,000개
+ * - 흐름: Reader -> Writer
+ *   - Reader: JdbcPagingItemReader로 product_metrics 테이블에서 집계하여 RankedProduct 반환
+ *   - Writer: Top 100을 ProductWeeklyRankingRepository에 저장
+ */
+@Configuration
+class ProductWeeklyRankingJobConfig(
+    private val jobRepository: JobRepository,
+    private val transactionManager: PlatformTransactionManager,
+) {
+
+    @Bean(name = [JOB_NAME])
+    fun productWeeklyRankingJob(
+        @Qualifier(STEP_NAME) step: Step,
+    ): Job {
+        return JobBuilder(JOB_NAME, jobRepository)
+            .preventRestart()
+            .start(step)
+            .build()
+    }
+
+    @Bean(name = [STEP_NAME])
+    fun productWeeklyRankingStep(
+        productWeeklyRankingReader: JdbcPagingItemReader<RankedProduct>,
+        productWeeklyRankingWriter: ProductWeeklyRankingWriter,
+    ): Step {
+        return StepBuilder(STEP_NAME, jobRepository)
+            .chunk<RankedProduct, RankedProduct>(CHUNK_SIZE, transactionManager)
+            .reader(productWeeklyRankingReader)
+            .writer(productWeeklyRankingWriter)
+            .build()
+    }
+
+    companion object {
+        const val JOB_NAME = "PRODUCT_WEEKLY_RANKING_JOB"
+        const val STEP_NAME = "PRODUCT_WEEKLY_RANKING_STEP"
+        const val CHUNK_SIZE = 1_000
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingJobConfig.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingJobConfig.kt
@@ -53,6 +53,6 @@ class ProductWeeklyRankingJobConfig(
     companion object {
         const val JOB_NAME = "PRODUCT_WEEKLY_RANKING_JOB"
         const val STEP_NAME = "PRODUCT_WEEKLY_RANKING_STEP"
-        const val CHUNK_SIZE = 1_000
+        const val CHUNK_SIZE = 100
     }
 }

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingProcessor.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingProcessor.kt
@@ -1,0 +1,61 @@
+package com.loopers.batch.productmetrics.ranking
+
+import com.loopers.domain.ranking.dto.ProductWeeklyMetricsAggregate
+import com.loopers.domain.ranking.dto.RankedProduct
+import org.springframework.batch.core.configuration.annotation.StepScope
+import org.springframework.batch.item.ItemProcessor
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+/**
+ * 주간 상품 랭킹 Processor
+ *
+ * ProductWeeklyMetricsAggregate를 받아서 날짜별 감쇠 가중치를 적용하여 점수 계산
+ *
+ * 가중치 공식:
+ * - (조회수 * viewWeight + 주문수 * soldWeight + 좋아요 * likeWeight) * 날짜별 감쇠 가중치
+ *
+ * 날짜별 감쇠 가중치:
+ * - D+0 (daysFromEnd=0): 1.0
+ * - D+1 (daysFromEnd=1): 0.9
+ * - D+2 (daysFromEnd=2): 0.8
+ * - D+3 (daysFromEnd=3): 0.4
+ * - D+4 (daysFromEnd=4): 0.3
+ * - D+5 (daysFromEnd=5): 0.2
+ * - D+6 (daysFromEnd=6): 0.1
+ */
+@Component
+@StepScope
+class ProductWeeklyRankingProcessor(
+    @Value("\${batch.ranking.weights.view:1}") private val viewWeight: Double,
+    @Value("\${batch.ranking.weights.like:5}") private val likeWeight: Double,
+    @Value("\${batch.ranking.weights.sold:10}") private val soldWeight: Double,
+) : ItemProcessor<ProductWeeklyMetricsAggregate, RankedProduct> {
+
+    override fun process(item: ProductWeeklyMetricsAggregate): RankedProduct {
+        // 날짜별 감쇠 가중치 계산
+        val decayWeight = when (item.daysFromEnd) {
+            0 -> 1.0
+            1 -> 0.9
+            2 -> 0.8
+            3 -> 0.4
+            4 -> 0.3
+            5 -> 0.2
+            6 -> 0.1
+            else -> 0.0
+        }
+
+        // 기본 점수 계산
+        val baseScore = item.viewCount * viewWeight +
+                item.soldCount * soldWeight +
+                item.likeCount * likeWeight
+
+        // 감쇠 가중치를 적용한 최종 점수
+        val finalScore = baseScore * decayWeight
+
+        return RankedProduct(
+            productId = item.productId,
+            finalScore = finalScore,
+        )
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingReader.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingReader.kt
@@ -1,0 +1,93 @@
+package com.loopers.batch.productmetrics.ranking
+
+import com.loopers.domain.ranking.dto.RankedProduct
+import org.springframework.batch.core.configuration.annotation.StepScope
+import org.springframework.batch.item.database.JdbcPagingItemReader
+import org.springframework.batch.item.database.Order
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder
+import org.springframework.batch.item.database.support.MySqlPagingQueryProvider
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.core.RowMapper
+import java.time.LocalDate
+import javax.sql.DataSource
+
+/**
+ * 주간 상품 메트릭 Reader
+ *
+ * productId별로 7일치 데이터를 집계하여 날짜별 감쇠 가중치를 적용한 점수 반환
+ * - JdbcPagingItemReader 사용으로 메모리 효율적 처리
+ * - productId별로 하나의 레코드만 반환하여 Chunk 경계 문제 해결
+ */
+@Configuration
+class ProductWeeklyRankingReader {
+
+    @Bean
+    @StepScope
+    fun weeklyRankingReader(
+        dataSource: DataSource,
+        @Value("#{jobParameters['weekStart']}") weekStart: String,
+        @Value("#{jobParameters['weekEnd']}") weekEnd: String,
+        @Value("\${batch.ranking.weights.view:1}") viewWeight: Double,
+        @Value("\${batch.ranking.weights.like:5}") likeWeight: Double,
+        @Value("\${batch.ranking.weights.sold:10}") soldWeight: Double,
+    ): JdbcPagingItemReader<RankedProduct> {
+        // SQL에서 날짜별 감쇠 가중치 적용하여 productId별 점수 집계
+        val selectClause = """
+            SELECT
+                product_id,
+                SUM(
+                    (view_count * $viewWeight + like_count * $likeWeight + sold_count * $soldWeight) *
+                    CASE
+                        WHEN DATEDIFF(CURDATE(), metric_date) = 1 THEN 1.0
+                        WHEN DATEDIFF(CURDATE(), metric_date) = 2 THEN 0.9
+                        WHEN DATEDIFF(CURDATE(), metric_date) = 3 THEN 0.8
+                        WHEN DATEDIFF(CURDATE(), metric_date) = 4 THEN 0.4
+                        WHEN DATEDIFF(CURDATE(), metric_date) = 5 THEN 0.3
+                        WHEN DATEDIFF(CURDATE(), metric_date) = 6 THEN 0.2
+                        WHEN DATEDIFF(CURDATE(), metric_date) = 7 THEN 0.1
+                        ELSE 0.0
+                    END
+                ) as final_score
+        """.trimIndent()
+
+        val fromClause = "FROM product_metrics"
+
+        val whereClause = """
+            WHERE metric_date BETWEEN :weekStart AND :weekEnd
+            GROUP BY product_id
+        """.trimIndent()
+
+        val sortKey = mapOf("final_score" to Order.DESCENDING)
+
+        val rowMapper = RowMapper { rs, _ ->
+            RankedProduct(
+                productId = rs.getLong("product_id"),
+                finalScore = rs.getDouble("final_score"),
+            )
+        }
+
+        return JdbcPagingItemReaderBuilder<RankedProduct>()
+            .name("productWeeklyRankingReader")
+            .dataSource(dataSource)
+            .queryProvider(
+                MySqlPagingQueryProvider().apply {
+                    setSelectClause(selectClause)
+                    setFromClause(fromClause)
+                    setWhereClause(whereClause)
+                    sortKeys = sortKey
+                },
+            )
+            .parameterValues(
+                mapOf(
+                    "weekStart" to LocalDate.parse(weekStart),
+                    "weekEnd" to LocalDate.parse(weekEnd),
+                ),
+            )
+            .pageSize(1000) // 1000개씩 페이징
+            .rowMapper(rowMapper)
+            .saveState(true) // Job 재시작 지원
+            .build()
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingReader.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingReader.kt
@@ -55,10 +55,7 @@ class ProductWeeklyRankingReader {
         val fromClause = "FROM product_metrics"
 
         // 주간 범위는 job 파라미터로 주입된 날짜를 그대로 사용
-        val whereClause = """
-            WHERE metric_date BETWEEN :weekStart AND :weekEnd
-            GROUP BY product_id
-        """.trimIndent()
+        val whereClause = "WHERE metric_date BETWEEN :weekStart AND :weekEnd"
 
         val sortKey = mapOf("final_score" to Order.DESCENDING)
 
@@ -77,6 +74,7 @@ class ProductWeeklyRankingReader {
                     setSelectClause(selectClause)
                     setFromClause(fromClause)
                     setWhereClause(whereClause)
+                    setGroupClause("product_id")
                     sortKeys = sortKey
                 },
             )
@@ -87,7 +85,7 @@ class ProductWeeklyRankingReader {
                     "weekEnd" to LocalDate.parse(weekEnd),
                 ),
             )
-            .pageSize(1000) // 1000개씩 페이징
+            .pageSize(100) // 100개씩 페이징
             .rowMapper(rowMapper)
             .saveState(true) // Job 재시작 지원
             .build()

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingReader.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingReader.kt
@@ -54,6 +54,7 @@ class ProductWeeklyRankingReader {
 
         val fromClause = "FROM product_metrics"
 
+        // 주간 범위는 job 파라미터로 주입된 날짜를 그대로 사용
         val whereClause = """
             WHERE metric_date BETWEEN :weekStart AND :weekEnd
             GROUP BY product_id
@@ -81,6 +82,7 @@ class ProductWeeklyRankingReader {
             )
             .parameterValues(
                 mapOf(
+                    // 문자열 파라미터를 LocalDate로 변환해 SQL 바인딩
                     "weekStart" to LocalDate.parse(weekStart),
                     "weekEnd" to LocalDate.parse(weekEnd),
                 ),

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingReader.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingReader.kt
@@ -40,13 +40,13 @@ class ProductWeeklyRankingReader {
                 SUM(
                     (view_count * $viewWeight + like_count * $likeWeight + sold_count * $soldWeight) *
                     CASE
-                        WHEN DATEDIFF(CURDATE(), metric_date) = 1 THEN 1.0
-                        WHEN DATEDIFF(CURDATE(), metric_date) = 2 THEN 0.9
-                        WHEN DATEDIFF(CURDATE(), metric_date) = 3 THEN 0.8
-                        WHEN DATEDIFF(CURDATE(), metric_date) = 4 THEN 0.4
-                        WHEN DATEDIFF(CURDATE(), metric_date) = 5 THEN 0.3
-                        WHEN DATEDIFF(CURDATE(), metric_date) = 6 THEN 0.2
-                        WHEN DATEDIFF(CURDATE(), metric_date) = 7 THEN 0.1
+                        WHEN DATEDIFF(:weekEnd, metric_date) = 0 THEN 1.0
+                        WHEN DATEDIFF(:weekEnd, metric_date) = 1 THEN 0.9
+                        WHEN DATEDIFF(:weekEnd, metric_date) = 2 THEN 0.8
+                        WHEN DATEDIFF(:weekEnd, metric_date) = 3 THEN 0.4
+                        WHEN DATEDIFF(:weekEnd, metric_date) = 4 THEN 0.3
+                        WHEN DATEDIFF(:weekEnd, metric_date) = 5 THEN 0.2
+                        WHEN DATEDIFF(:weekEnd, metric_date) = 6 THEN 0.1
                         ELSE 0.0
                     END
                 ) as final_score

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingWriter.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingWriter.kt
@@ -4,85 +4,144 @@ import com.loopers.domain.ranking.ProductWeeklyRanking
 import com.loopers.domain.ranking.ProductWeeklyRankingRepository
 import com.loopers.domain.ranking.dto.RankedProduct
 import org.slf4j.LoggerFactory
+import org.springframework.batch.core.StepExecution
+import org.springframework.batch.core.annotation.AfterStep
+import org.springframework.batch.core.annotation.BeforeStep
 import org.springframework.batch.core.configuration.annotation.StepScope
 import org.springframework.batch.item.Chunk
 import org.springframework.batch.item.ItemWriter
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.LocalDate
 
 /**
  * 주간 상품 랭킹 Writer
  *
- * RankedProduct를 받아서 productId별로 점수를 합산하고 Top 100을 저장
+ * RankedProduct를 받아서 임시 테이블에 누적하고, AfterStep에서 productId별로 점수를 합산하여 Top 100을 저장
+ *
+ * 메모리 사용량을 최소화하기 위해 임시 테이블(temp_weekly_ranking)을 활용:
+ * 1. BeforeStep: 임시 테이블 생성 및 기존 데이터 삭제
+ * 2. write(): 청크 단위로 임시 테이블에 INSERT ... ON DUPLICATE KEY UPDATE
+ * 3. AfterStep: 임시 테이블에서 Top 100 추출 후 저장
  */
 @Component
 @StepScope
 class ProductWeeklyRankingWriter(
+    private val jdbcTemplate: JdbcTemplate,
     private val repository: ProductWeeklyRankingRepository,
+    private val transactionTemplate: TransactionTemplate,
     @Value("#{jobParameters['weekStart']}") private val weekStart: String,
     @Value("#{jobParameters['weekEnd']}") private val weekEnd: String,
 ) : ItemWriter<RankedProduct> {
 
     private val log = LoggerFactory.getLogger(ProductWeeklyRankingWriter::class.java)
-    // State kept across chunks to build a single Top 100 list.
-    private var initialized = false
-    private var rankCounter = 0
 
-    @Transactional
+    @BeforeStep
+    fun beforeStep(stepExecution: StepExecution) {
+        // 임시 테이블 생성 (이미 존재하면 재사용)
+        jdbcTemplate.execute(
+            """
+            CREATE TEMPORARY TABLE IF NOT EXISTS temp_weekly_ranking (
+                product_id BIGINT NOT NULL,
+                score DOUBLE NOT NULL DEFAULT 0,
+                PRIMARY KEY (product_id)
+            )
+            """.trimIndent(),
+        )
+
+        // 임시 테이블 초기화 (이전 실행 데이터 제거)
+        jdbcTemplate.execute("TRUNCATE TABLE temp_weekly_ranking")
+
+        log.info("Initialized temp_weekly_ranking table")
+    }
+
     override fun write(chunk: Chunk<out RankedProduct>) {
-        val items = chunk.items
-
-        if (items.isEmpty()) {
+        if (chunk.isEmpty) {
             return
         }
 
-        // Job 파라미터를 주차 범위로 파싱
+        // 임시 테이블에 청크 데이터 삽입 (중복 시 점수 합산)
+        val sql = """
+            INSERT INTO temp_weekly_ranking (product_id, score)
+            VALUES (?, ?)
+            ON DUPLICATE KEY UPDATE score = score + VALUES(score)
+        """.trimIndent()
+
+        jdbcTemplate.batchUpdate(
+            sql,
+            chunk.items,
+            chunk.size(),
+        ) { ps, item ->
+            ps.setLong(1, item.productId)
+            ps.setDouble(2, item.finalScore)
+        }
+
+        log.debug("Inserted {} products into temp_weekly_ranking", chunk.size())
+    }
+
+    @AfterStep
+    fun afterStep(stepExecution: StepExecution) {
+        if (stepExecution.exitStatus.exitCode != "COMPLETED") {
+            log.warn("Step did not complete successfully. Skipping weekly ranking save.")
+            return
+        }
+
         val start = LocalDate.parse(weekStart)
         val end = LocalDate.parse(weekEnd)
 
-        if (!initialized) {
-            // 동일 주차 데이터는 삭제 후 재적재하여 멱등성 확보
-            repository.deleteByWeekStartAndWeekEnd(start, end)
-            initialized = true
-        }
+        // 임시 테이블에서 총 상품 수 확인
+        val totalProducts = jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM temp_weekly_ranking",
+            Long::class.java,
+        ) ?: 0L
 
-        // Reader가 점수 내림차순 정렬을 보장하므로 Top 100까지만 순차 저장.
-        if (rankCounter >= 100) {
+        if (totalProducts == 0L) {
+            log.warn("No ranked products to save")
             return
         }
 
-        // 엔티티로 변환 (순위 포함)
-        val entities = mutableListOf<ProductWeeklyRanking>()
-        for (rankedProduct in items) {
-            if (rankCounter >= 100) {
-                break
-            }
-
-            rankCounter += 1
-            entities.add(
-                ProductWeeklyRanking.create(
-                    ranking = rankCounter,
-                    productId = rankedProduct.productId,
-                    score = rankedProduct.finalScore,
-                    weekStart = start,
-                    weekEnd = end,
-                ),
+        // 임시 테이블에서 Top 100 추출 (점수 내림차순)
+        val top100 = jdbcTemplate.query(
+            """
+            SELECT
+                product_id,
+                score,
+                ROW_NUMBER() OVER (ORDER BY score DESC) as ranking
+            FROM temp_weekly_ranking
+            ORDER BY score DESC
+            LIMIT 100
+            """.trimIndent(),
+        ) { rs, _ ->
+            ProductWeeklyRanking.create(
+                ranking = rs.getInt("ranking"),
+                productId = rs.getLong("product_id"),
+                score = rs.getDouble("score"),
+                weekStart = start,
+                weekEnd = end,
             )
         }
 
-        if (entities.isEmpty()) {
-            return
+        // 트랜잭션 내에서 삭제 및 저장 작업 수행
+        transactionTemplate.execute {
+            // 동일 주차 데이터는 삭제 후 재적재하여 멱등성 확보
+            repository.deleteByWeekStartAndWeekEnd(start, end)
+
+            // Top 100 저장
+            repository.saveAll(top100)
         }
 
-        repository.saveAll(entities)
-
         log.info(
-            "Saved {} weekly rankings (Top 100) for week {} to {}",
-            entities.size,
+            "Saved Top {} weekly rankings for week {} to {} (total products: {})",
+            top100.size,
             start,
             end,
+            totalProducts,
         )
+
+        // 임시 테이블 정리
+        jdbcTemplate.execute("DROP TEMPORARY TABLE IF EXISTS temp_weekly_ranking")
+        log.debug("Dropped temp_weekly_ranking table")
     }
 }

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingWriter.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/batch/productmetrics/ranking/ProductWeeklyRankingWriter.kt
@@ -1,0 +1,90 @@
+package com.loopers.batch.productmetrics.ranking
+
+import com.loopers.domain.ranking.ProductWeeklyRanking
+import com.loopers.domain.ranking.ProductWeeklyRankingRepository
+import com.loopers.domain.ranking.dto.RankedProduct
+import org.slf4j.LoggerFactory
+import org.springframework.batch.core.configuration.annotation.StepScope
+import org.springframework.batch.item.Chunk
+import org.springframework.batch.item.ItemWriter
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+/**
+ * 주간 상품 랭킹 Writer
+ *
+ * RankedProduct를 받아서 productId별로 점수를 합산하고 Top 100을 저장
+ */
+@Component
+@StepScope
+class ProductWeeklyRankingWriter(
+    private val repository: ProductWeeklyRankingRepository,
+    @Value("#{jobParameters['weekStart']}") private val weekStart: String,
+    @Value("#{jobParameters['weekEnd']}") private val weekEnd: String,
+) : ItemWriter<RankedProduct> {
+
+    private val log = LoggerFactory.getLogger(ProductWeeklyRankingWriter::class.java)
+
+    @Transactional
+    override fun write(chunk: Chunk<out RankedProduct>) {
+        val items = chunk.items
+
+        if (items.isEmpty()) {
+            return
+        }
+
+        val start = LocalDate.parse(weekStart)
+        val end = LocalDate.parse(weekEnd)
+
+        // 기존 랭킹 데이터 로드
+        val existingRankings = repository.findByWeekStartAndWeekEnd(start, end)
+        val existingScores = existingRankings.associate { it.productId to it.score.toDouble() }
+
+        // 기존 데이터와 새 데이터 병합 (productId별로 점수 합산)
+        val mergedScores = mutableMapOf<Long, Double>()
+
+        // 기존 데이터 추가
+        existingScores.forEach { (productId, score) ->
+            mergedScores[productId] = score
+        }
+
+        // 새 데이터 추가 (이미 있으면 합산)
+        items.forEach { rankedProduct ->
+            mergedScores[rankedProduct.productId] =
+                mergedScores.getOrDefault(rankedProduct.productId, 0.0) + rankedProduct.finalScore
+        }
+
+        // Top 100 추출 (점수 내림차순)
+        val top100 = mergedScores
+            .map { (productId, score) -> RankedProduct(productId, score) }
+            .sortedByDescending { it.finalScore }
+            .take(100)
+
+        // 기존 데이터 삭제 (Top 100으로 교체하기 위해)
+        if (existingRankings.isNotEmpty()) {
+            repository.deleteByWeekStartAndWeekEnd(start, end)
+        }
+
+        // 엔티티로 변환 (순위 포함)
+        val entities = top100.mapIndexed { index, rankedProduct ->
+            ProductWeeklyRanking.create(
+                ranking = index + 1,
+                productId = rankedProduct.productId,
+                score = rankedProduct.finalScore,
+                weekStart = start,
+                weekEnd = end,
+            )
+        }
+
+        repository.saveAll(entities)
+
+        log.info(
+            "Saved {} weekly rankings (Top 100) for week {} to {}",
+            entities.size,
+            start,
+            end,
+        )
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/metrics/ProductMetrics.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/metrics/ProductMetrics.kt
@@ -1,0 +1,87 @@
+package com.loopers.domain.metrics
+
+import jakarta.persistence.Column
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.Version
+import java.time.LocalDate
+import java.time.ZonedDateTime
+
+/**
+ * 상품 메트릭 집계 테이블 (일자별 이력 관리)
+ *
+ * Kafka 이벤트를 통해 수집된 상품 관련 메트릭을 일자별로 집계
+ * - 좋아요 수
+ * - 조회 수
+ * - 판매 수량
+ */
+@Entity
+@Table(
+    name = "product_metrics",
+    indexes = [
+        Index(name = "idx_metric_date", columnList = "metric_date"),
+        Index(name = "idx_product_id", columnList = "product_id"),
+    ],
+)
+class ProductMetrics(
+    @EmbeddedId
+    val id: ProductMetricsId,
+
+    @Column(name = "like_count", nullable = false)
+    var likeCount: Long = 0,
+
+    @Column(name = "view_count", nullable = false)
+    var viewCount: Long = 0,
+
+    @Column(name = "sold_count", nullable = false)
+    var soldCount: Long = 0,
+
+    @Version
+    @Column(name = "version", nullable = false)
+    var version: Long = 0,
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: ZonedDateTime = ZonedDateTime.now(),
+) {
+    fun increaseLikeCount() {
+        this.likeCount++
+        this.updatedAt = ZonedDateTime.now()
+    }
+
+    fun decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--
+        }
+        this.updatedAt = ZonedDateTime.now()
+    }
+
+    fun increaseViewCount() {
+        this.viewCount++
+        this.updatedAt = ZonedDateTime.now()
+    }
+
+    fun increaseSoldCount(quantity: Int) {
+        this.soldCount += quantity
+        this.updatedAt = ZonedDateTime.now()
+    }
+
+    fun decreaseSoldCount(quantity: Int) {
+        if (this.soldCount >= quantity) {
+            this.soldCount -= quantity
+        }
+        this.updatedAt = ZonedDateTime.now()
+    }
+
+    companion object {
+        fun create(productId: Long, metricDate: LocalDate): ProductMetrics {
+            return ProductMetrics(
+                id = ProductMetricsId(productId, metricDate),
+                likeCount = 0,
+                viewCount = 0,
+                soldCount = 0,
+            )
+        }
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/metrics/ProductMetrics.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/metrics/ProductMetrics.kt
@@ -5,7 +5,6 @@ import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
 import jakarta.persistence.Index
 import jakarta.persistence.Table
-import jakarta.persistence.Version
 import java.time.LocalDate
 import java.time.ZonedDateTime
 
@@ -38,42 +37,9 @@ class ProductMetrics(
     @Column(name = "sold_count", nullable = false)
     var soldCount: Long = 0,
 
-    @Version
-    @Column(name = "version", nullable = false)
-    var version: Long = 0,
-
     @Column(name = "updated_at", nullable = false)
     var updatedAt: ZonedDateTime = ZonedDateTime.now(),
 ) {
-    fun increaseLikeCount() {
-        this.likeCount++
-        this.updatedAt = ZonedDateTime.now()
-    }
-
-    fun decreaseLikeCount() {
-        if (this.likeCount > 0) {
-            this.likeCount--
-        }
-        this.updatedAt = ZonedDateTime.now()
-    }
-
-    fun increaseViewCount() {
-        this.viewCount++
-        this.updatedAt = ZonedDateTime.now()
-    }
-
-    fun increaseSoldCount(quantity: Int) {
-        this.soldCount += quantity
-        this.updatedAt = ZonedDateTime.now()
-    }
-
-    fun decreaseSoldCount(quantity: Int) {
-        if (this.soldCount >= quantity) {
-            this.soldCount -= quantity
-        }
-        this.updatedAt = ZonedDateTime.now()
-    }
-
     companion object {
         fun create(productId: Long, metricDate: LocalDate): ProductMetrics {
             return ProductMetrics(

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/metrics/ProductMetricsId.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/metrics/ProductMetricsId.kt
@@ -1,0 +1,21 @@
+package com.loopers.domain.metrics
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import java.io.Serializable
+import java.time.LocalDate
+
+/**
+ * ProductMetrics 복합키
+ *
+ * @property productId 상품 ID
+ * @property metricDate 메트릭 집계 일자
+ */
+@Embeddable
+data class ProductMetricsId(
+    @Column(name = "product_id", nullable = false)
+    val productId: Long,
+
+    @Column(name = "metric_date", nullable = false)
+    val metricDate: LocalDate,
+) : Serializable

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/ranking/ProductMonthlyRanking.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/ranking/ProductMonthlyRanking.kt
@@ -1,0 +1,63 @@
+package com.loopers.domain.ranking
+
+import com.loopers.infrastructure.converter.YearMonthAttributeConverter
+import jakarta.persistence.Column
+import jakarta.persistence.Convert
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.YearMonth
+import java.time.ZonedDateTime
+
+@Entity
+@Table(
+    name = "mv_product_rank_monthly",
+    indexes = [
+        Index(name = "idx_month_period", columnList = "month_period"),
+        Index(name = "idx_score", columnList = "score"),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(name = "uq_monthly_rank", columnNames = ["product_id", "month_period"]),
+    ],
+)
+class ProductMonthlyRanking(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "ranking", nullable = false)
+    val ranking: Int = 0,
+
+    @Column(name = "product_id", nullable = false)
+    val productId: Long = 0,
+
+    @Column(name = "score", nullable = false)
+    val score: Double = 0.0,
+
+    @Convert(converter = YearMonthAttributeConverter::class)
+    @Column(name = "month_period", nullable = false)
+    val monthPeriod: YearMonth,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: ZonedDateTime = ZonedDateTime.now(),
+) {
+    companion object {
+        fun create(
+            ranking: Int,
+            productId: Long,
+            score: Double,
+            monthPeriod: YearMonth,
+        ): ProductMonthlyRanking {
+            return ProductMonthlyRanking(
+                ranking = ranking,
+                productId = productId,
+                score = score,
+                monthPeriod = monthPeriod,
+            )
+        }
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/ranking/ProductMonthlyRankingRepository.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/ranking/ProductMonthlyRankingRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.domain.ranking
+
+interface ProductMonthlyRankingRepository {
+    fun saveAll(monthlyRankings: List<ProductMonthlyRanking>): List<ProductMonthlyRanking>
+
+    fun findByMonthPeriod(monthPeriod: java.time.YearMonth): List<ProductMonthlyRanking>
+
+    fun deleteByMonthPeriod(monthPeriod: java.time.YearMonth)
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/ranking/ProductWeeklyRanking.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/ranking/ProductWeeklyRanking.kt
@@ -1,0 +1,70 @@
+package com.loopers.domain.ranking
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.LocalDate
+import java.time.ZonedDateTime
+
+/**
+ * 주간 상품 랭킹 집계 테이블
+ *
+ * 일자별 product_metrics를 주 단위로 집계하여 상품별 랭킹 점수 저장
+ */
+@Entity
+@Table(
+    name = "mv_product_rank_weekly",
+    indexes = [
+        Index(name = "idx_week", columnList = "week_start, week_end"),
+        Index(name = "idx_score", columnList = "score"),
+    ],
+    uniqueConstraints = [
+        UniqueConstraint(name = "uq_weekly_rank", columnNames = ["product_id", "week_start", "week_end"]),
+    ],
+)
+class ProductWeeklyRanking(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "ranking", nullable = false)
+    val ranking: Int = 0,
+
+    @Column(name = "product_id", nullable = false)
+    val productId: Long = 0,
+
+    @Column(name = "score", nullable = false)
+    val score: Double = 0.0,
+
+    @Column(name = "week_start", nullable = false)
+    val weekStart: LocalDate,
+
+    @Column(name = "week_end", nullable = false)
+    val weekEnd: LocalDate,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: ZonedDateTime = ZonedDateTime.now(),
+) {
+    companion object {
+        fun create(
+            ranking: Int,
+            productId: Long,
+            score: Double,
+            weekStart: LocalDate,
+            weekEnd: LocalDate,
+        ): ProductWeeklyRanking {
+            return ProductWeeklyRanking(
+                ranking = ranking,
+                productId = productId,
+                score = score,
+                weekStart = weekStart,
+                weekEnd = weekEnd,
+            )
+        }
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/ranking/ProductWeeklyRankingRepository.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/ranking/ProductWeeklyRankingRepository.kt
@@ -1,0 +1,25 @@
+package com.loopers.domain.ranking
+
+import java.time.LocalDate
+
+/**
+ * 주간 상품 랭킹 Repository
+ */
+interface ProductWeeklyRankingRepository {
+    fun saveAll(weeklyRankings: List<ProductWeeklyRanking>): List<ProductWeeklyRanking>
+
+    fun findByWeekStartAndWeekEnd(weekStart: LocalDate, weekEnd: LocalDate): List<ProductWeeklyRanking>
+
+    /**
+     * Upsert를 위한 특정 상품의 주차별 랭킹 조회
+     */
+    fun findByProductIdAndWeekStartAndWeekEnd(
+        productId: Long,
+        weekStart: LocalDate,
+        weekEnd: LocalDate,
+    ): List<ProductWeeklyRanking>
+
+    fun findByWeekRange(monthStart: LocalDate, monthEnd: LocalDate): List<ProductWeeklyRanking>
+
+    fun deleteByWeekStartAndWeekEnd(weekStart: LocalDate, weekEnd: LocalDate)
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/ranking/dto/ProductMonthlyMetricsAggregate.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/ranking/dto/ProductMonthlyMetricsAggregate.kt
@@ -1,0 +1,18 @@
+package com.loopers.domain.ranking.dto
+
+/**
+ * 월간 상품 메트릭 집계 DTO
+ *
+ * Reader가 GROUP BY로 집계한 원본 메트릭 값
+ *
+ * @property productId 상품 ID
+ * @property totalViewCount 총 조회수
+ * @property totalLikeCount 총 좋아요수
+ * @property totalSoldCount 총 판매수
+ */
+data class ProductMonthlyMetricsAggregate(
+    val productId: Long,
+    val totalViewCount: Long,
+    val totalLikeCount: Long,
+    val totalSoldCount: Long,
+)

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/ranking/dto/ProductWeeklyMetricsAggregate.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/ranking/dto/ProductWeeklyMetricsAggregate.kt
@@ -1,0 +1,20 @@
+package com.loopers.domain.ranking.dto
+
+/**
+ * 주간 상품 메트릭 날짜별 집계 DTO
+ *
+ * Reader가 날짜별로 집계한 메트릭 값 (7개 레코드 = 7일치)
+ *
+ * @property productId 상품 ID
+ * @property daysFromEnd 주간 종료일로부터의 일수 (0~6)
+ * @property viewCount 조회수
+ * @property likeCount 좋아요수
+ * @property soldCount 판매수
+ */
+data class ProductWeeklyMetricsAggregate(
+    val productId: Long,
+    val daysFromEnd: Int,
+    val viewCount: Long,
+    val likeCount: Long,
+    val soldCount: Long,
+)

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/ranking/dto/RankedProduct.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/ranking/dto/RankedProduct.kt
@@ -1,0 +1,12 @@
+package com.loopers.domain.ranking.dto
+
+/**
+ * 랭킹 계산된 상품 DTO
+ *
+ * @property productId 상품 ID
+ * @property finalScore 최종 점수 (기본 점수 × 날짜별 감쇠 가중치)
+ */
+data class RankedProduct(
+    val productId: Long,
+    val finalScore: Double,
+)

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/converter/YearMonthAttributeConverter.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/converter/YearMonthAttributeConverter.kt
@@ -1,0 +1,17 @@
+package com.loopers.infrastructure.converter
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+import java.time.YearMonth
+
+@Converter(autoApply = true)
+class YearMonthAttributeConverter : AttributeConverter<YearMonth, String> {
+
+    override fun convertToDatabaseColumn(attribute: YearMonth?): String? {
+        return attribute?.toString() // "yyyy-MM"
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): YearMonth? {
+        return dbData?.let { YearMonth.parse(it) }
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.metrics
+
+import com.loopers.domain.metrics.ProductMetrics
+import com.loopers.domain.metrics.ProductMetricsId
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProductMetricsJpaRepository : JpaRepository<ProductMetrics, ProductMetricsId>

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductMonthlyRankingJpaRepository.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductMonthlyRankingJpaRepository.kt
@@ -1,0 +1,26 @@
+package com.loopers.infrastructure.ranking
+
+import com.loopers.domain.ranking.ProductMonthlyRanking
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.YearMonth
+
+/**
+ * 월간 상품 랭킹 JPA Repository
+ */
+interface ProductMonthlyRankingJpaRepository : JpaRepository<ProductMonthlyRanking, Long> {
+    fun findByMonthPeriod(monthPeriod: YearMonth): List<ProductMonthlyRanking>
+
+    @Modifying
+    @Query(
+        """
+        DELETE FROM ProductMonthlyRanking m
+        WHERE m.monthPeriod = :monthPeriod
+    """,
+    )
+    fun deleteByMonthPeriod(
+        @Param("monthPeriod") monthPeriod: YearMonth,
+    )
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductMonthlyRankingJpaRepository.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductMonthlyRankingJpaRepository.kt
@@ -7,9 +7,6 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.YearMonth
 
-/**
- * 월간 상품 랭킹 JPA Repository
- */
 interface ProductMonthlyRankingJpaRepository : JpaRepository<ProductMonthlyRanking, Long> {
     fun findByMonthPeriod(monthPeriod: YearMonth): List<ProductMonthlyRanking>
 

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductMonthlyRankingRepositoryImpl.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductMonthlyRankingRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.loopers.infrastructure.ranking
+
+import com.loopers.domain.ranking.ProductMonthlyRanking
+import com.loopers.domain.ranking.ProductMonthlyRankingRepository
+import java.time.YearMonth
+import org.springframework.stereotype.Repository
+
+/**
+ * 주간 상품 랭킹 Repository 구현체
+ */
+@Repository
+class ProductMonthlyRankingRepositoryImpl(
+    private val productMonthlyRankingJpaRepository: ProductMonthlyRankingJpaRepository,
+) : ProductMonthlyRankingRepository {
+
+    override fun saveAll(monthlyRankings: List<ProductMonthlyRanking>): List<ProductMonthlyRanking> {
+        return productMonthlyRankingJpaRepository.saveAll(monthlyRankings)
+    }
+
+    override fun findByMonthPeriod(monthPeriod: YearMonth): List<ProductMonthlyRanking> {
+        return productMonthlyRankingJpaRepository.findByMonthPeriod(monthPeriod)
+    }
+
+    override fun deleteByMonthPeriod(monthPeriod: YearMonth) {
+        productMonthlyRankingJpaRepository.deleteByMonthPeriod(monthPeriod)
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductMonthlyRankingRepositoryImpl.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductMonthlyRankingRepositoryImpl.kt
@@ -5,9 +5,6 @@ import com.loopers.domain.ranking.ProductMonthlyRankingRepository
 import java.time.YearMonth
 import org.springframework.stereotype.Repository
 
-/**
- * 주간 상품 랭킹 Repository 구현체
- */
 @Repository
 class ProductMonthlyRankingRepositoryImpl(
     private val productMonthlyRankingJpaRepository: ProductMonthlyRankingJpaRepository,

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductWeeklyRankingJpaRepository.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductWeeklyRankingJpaRepository.kt
@@ -1,0 +1,51 @@
+package com.loopers.infrastructure.ranking
+
+import com.loopers.domain.ranking.ProductWeeklyRanking
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDate
+
+/**
+ * 주간 상품 랭킹 JPA Repository
+ */
+interface ProductWeeklyRankingJpaRepository : JpaRepository<ProductWeeklyRanking, Long> {
+
+    fun findByWeekStartAndWeekEnd(weekStart: LocalDate, weekEnd: LocalDate): List<ProductWeeklyRanking>
+
+    /**
+     * 특정 상품의 주차별 랭킹 조회
+     */
+    fun findByProductIdAndWeekStartAndWeekEnd(
+        productId: Long,
+        weekStart: LocalDate,
+        weekEnd: LocalDate,
+    ): List<ProductWeeklyRanking>
+
+    @Query(
+        """
+        SELECT w
+        FROM ProductWeeklyRanking w
+        WHERE w.weekStart <= :monthEnd
+          AND w.weekEnd >= :monthStart
+    """,
+    )
+    fun findByWeekRange(
+        @Param("monthStart") monthStart: LocalDate,
+        @Param("monthEnd") monthEnd: LocalDate,
+    ): List<ProductWeeklyRanking>
+
+    @Modifying
+    @Query(
+        """
+        DELETE FROM ProductWeeklyRanking w
+        WHERE w.weekStart = :weekStart
+          AND w.weekEnd = :weekEnd
+    """,
+    )
+    fun deleteByWeekStartAndWeekEnd(
+        @Param("weekStart") weekStart: LocalDate,
+        @Param("weekEnd") weekEnd: LocalDate,
+    )
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductWeeklyRankingJpaRepository.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductWeeklyRankingJpaRepository.kt
@@ -7,9 +7,6 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDate
 
-/**
- * 주간 상품 랭킹 JPA Repository
- */
 interface ProductWeeklyRankingJpaRepository : JpaRepository<ProductWeeklyRanking, Long> {
 
     fun findByWeekStartAndWeekEnd(weekStart: LocalDate, weekEnd: LocalDate): List<ProductWeeklyRanking>

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductWeeklyRankingRepositoryImpl.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductWeeklyRankingRepositoryImpl.kt
@@ -1,0 +1,43 @@
+package com.loopers.infrastructure.ranking
+
+import com.loopers.domain.ranking.ProductWeeklyRanking
+import com.loopers.domain.ranking.ProductWeeklyRankingRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+/**
+ * 주간 상품 랭킹 Repository 구현체
+ */
+@Repository
+class ProductWeeklyRankingRepositoryImpl(
+    private val productWeeklyRankingJpaRepository: ProductWeeklyRankingJpaRepository,
+) : ProductWeeklyRankingRepository {
+
+    override fun saveAll(weeklyRankings: List<ProductWeeklyRanking>): List<ProductWeeklyRanking> {
+        return productWeeklyRankingJpaRepository.saveAll(weeklyRankings)
+    }
+
+    override fun findByWeekStartAndWeekEnd(weekStart: LocalDate, weekEnd: LocalDate): List<ProductWeeklyRanking> {
+        return productWeeklyRankingJpaRepository.findByWeekStartAndWeekEnd(weekStart, weekEnd)
+    }
+
+    override fun findByProductIdAndWeekStartAndWeekEnd(
+        productId: Long,
+        weekStart: LocalDate,
+        weekEnd: LocalDate,
+    ): List<ProductWeeklyRanking> {
+        return productWeeklyRankingJpaRepository.findByProductIdAndWeekStartAndWeekEnd(
+            productId,
+            weekStart,
+            weekEnd,
+        )
+    }
+
+    override fun findByWeekRange(monthStart: LocalDate, monthEnd: LocalDate): List<ProductWeeklyRanking> {
+        return productWeeklyRankingJpaRepository.findByWeekRange(monthStart, monthEnd)
+    }
+
+    override fun deleteByWeekStartAndWeekEnd(weekStart: LocalDate, weekEnd: LocalDate) {
+        productWeeklyRankingJpaRepository.deleteByWeekStartAndWeekEnd(weekStart, weekEnd)
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductWeeklyRankingRepositoryImpl.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/ranking/ProductWeeklyRankingRepositoryImpl.kt
@@ -5,9 +5,6 @@ import com.loopers.domain.ranking.ProductWeeklyRankingRepository
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
 
-/**
- * 주간 상품 랭킹 Repository 구현체
- */
 @Repository
 class ProductWeeklyRankingRepositoryImpl(
     private val productWeeklyRankingJpaRepository: ProductWeeklyRankingJpaRepository,

--- a/apps/commerce-batch/src/main/resources/application.yml
+++ b/apps/commerce-batch/src/main/resources/application.yml
@@ -1,0 +1,46 @@
+spring:
+  batch:
+    job:
+      enabled: false # 서버 재시작시 배치 자동실행 방지
+      name: ${job.name:NONE}
+    jdbc:
+      initialize-schema: never
+  main:
+    web-application-type: none
+  application:
+    name: commerce-batch
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - logging.yml
+      - monitoring.yml
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/apps/commerce-batch/src/main/resources/application.yml
+++ b/apps/commerce-batch/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
       enabled: false # 서버 재시작시 배치 자동실행 방지
       name: ${job.name:NONE}
     jdbc:
-      initialize-schema: never
+      initialize-schema: always
   main:
     web-application-type: none
   application:
@@ -16,6 +16,14 @@ spring:
       - jpa.yml
       - logging.yml
       - monitoring.yml
+
+# 배치 랭킹 가중치 설정
+batch:
+  ranking:
+    weights:
+      view: 0.1    # 조회수 가중치
+      like: 0.2   # 좋아요 가중치
+      sold: 0.7   # 판매수 가중치
 
 ---
 spring:

--- a/apps/commerce-batch/src/main/resources/application.yml
+++ b/apps/commerce-batch/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     jdbc:
       initialize-schema: always
   main:
-    web-application-type: none
+    web-application-type: servlet
   application:
     name: commerce-batch
   profiles:

--- a/apps/commerce-batch/src/test/kotlin/com/loopers/IntegrationTest.kt
+++ b/apps/commerce-batch/src/test/kotlin/com/loopers/IntegrationTest.kt
@@ -1,0 +1,22 @@
+package com.loopers
+
+import com.loopers.utils.DatabaseCleanUp
+import org.junit.jupiter.api.AfterEach
+import org.springframework.batch.test.context.SpringBatchTest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@ActiveProfiles("test")
+@SpringBatchTest
+@SpringBootTest
+abstract class IntegrationTest {
+
+    @Autowired
+    private lateinit var databaseCleanUp: DatabaseCleanUp
+
+    @AfterEach
+    fun tearDown() {
+        databaseCleanUp.truncateAllTables()
+    }
+}

--- a/apps/commerce-batch/src/test/kotlin/com/loopers/batch/productmetrics/batch/ranking/ProductMonthlyRankingJobTest.kt
+++ b/apps/commerce-batch/src/test/kotlin/com/loopers/batch/productmetrics/batch/ranking/ProductMonthlyRankingJobTest.kt
@@ -45,6 +45,7 @@ class ProductMonthlyRankingJobTest : IntegrationTest() {
     @DisplayName("전체 배치 흐름이 정상적으로 동작한다")
     fun testCompleteJobExecution() {
         // given: 10개 상품의 월간 메트릭 데이터 준비 (2일)
+        // 점수 계산: view * 0.1 + like * 0.2 + sold * 0.7
         val firstDay = monthStart
         val secondDay = monthStart.plusDays(7)
 
@@ -52,9 +53,13 @@ class ProductMonthlyRankingJobTest : IntegrationTest() {
         (1L..10L).forEach { productId ->
             val day1 = ProductMetrics.create(productId, firstDay).apply {
                 viewCount = productId * 10
+                likeCount = productId * 5
+                soldCount = productId * 2
             }
             val day2 = ProductMetrics.create(productId, secondDay).apply {
                 viewCount = productId * 5
+                likeCount = productId * 3
+                soldCount = productId
             }
             metrics.add(day1)
             metrics.add(day2)
@@ -86,6 +91,7 @@ class ProductMonthlyRankingJobTest : IntegrationTest() {
             assertThat(sortedByRanking[i].score).isGreaterThanOrEqualTo(sortedByRanking[i + 1].score)
         }
 
+        // 가중치 적용 시 productId가 클수록 점수가 높음 (sold가 가장 큰 가중치)
         val top1 = rankings.find { it.ranking == 1 }
         assertThat(top1).isNotNull
         assertThat(top1!!.productId).isEqualTo(10L)
@@ -95,9 +101,12 @@ class ProductMonthlyRankingJobTest : IntegrationTest() {
     @DisplayName("150개 상품 중 Top 100만 저장한다")
     fun testSavesOnlyTop100() {
         // given: 150개 상품 월간 메트릭 데이터
+        // 점수가 높은 순으로: productId 1이 가장 높음
         val metrics = (1L..150L).map { productId ->
             ProductMetrics.create(productId, monthStart).apply {
-                viewCount = 150 - productId
+                viewCount = (150 - productId) * 10
+                likeCount = (150 - productId) * 5
+                soldCount = (150 - productId) * 2
             }
         }
         productMetricsJpaRepository.saveAll(metrics)
@@ -130,7 +139,9 @@ class ProductMonthlyRankingJobTest : IntegrationTest() {
         // given: 첫 번째 실행용 데이터 (50개)
         val firstBatch = (1L..50L).map { productId ->
             ProductMetrics.create(productId, monthStart).apply {
-                viewCount = productId
+                viewCount = productId * 10
+                likeCount = productId * 5
+                soldCount = productId * 2
             }
         }
         productMetricsJpaRepository.saveAll(firstBatch)
@@ -144,10 +155,12 @@ class ProductMonthlyRankingJobTest : IntegrationTest() {
         val execution1 = jobLauncherTestUtils.launchJob(jobParameters1)
         assertThat(execution1.status).isEqualTo(BatchStatus.COMPLETED)
 
-        // 추가 데이터 저장 (51~150)
+        // 추가 데이터 저장 (51~150) - 더 높은 점수
         val secondBatch = (51L..150L).map { productId ->
             ProductMetrics.create(productId, monthStart.plusDays(7)).apply {
-                viewCount = productId * 10
+                viewCount = productId * 100
+                likeCount = productId * 50
+                soldCount = productId * 20
             }
         }
         productMetricsJpaRepository.saveAll(secondBatch)
@@ -196,6 +209,8 @@ class ProductMonthlyRankingJobTest : IntegrationTest() {
         productMetricsJpaRepository.save(
             ProductMetrics.create(1L, monthStart).apply {
                 viewCount = 100
+                likeCount = 50
+                soldCount = 20
             },
         )
 

--- a/apps/commerce-batch/src/test/kotlin/com/loopers/batch/productmetrics/batch/ranking/ProductMonthlyRankingJobTest.kt
+++ b/apps/commerce-batch/src/test/kotlin/com/loopers/batch/productmetrics/batch/ranking/ProductMonthlyRankingJobTest.kt
@@ -1,0 +1,256 @@
+package com.loopers.batch.productmetrics.batch.ranking
+
+import com.loopers.IntegrationTest
+import com.loopers.batch.productmetrics.ranking.ProductMonthlyRankingJobConfig
+import com.loopers.domain.ranking.ProductMonthlyRankingRepository
+import com.loopers.domain.ranking.ProductWeeklyRanking
+import com.loopers.domain.ranking.ProductWeeklyRankingRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.batch.core.BatchStatus
+import org.springframework.batch.core.Job
+import org.springframework.batch.core.JobParametersBuilder
+import org.springframework.batch.test.JobLauncherTestUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import java.time.YearMonth
+
+@DisplayName("ProductMonthlyRankingJob 통합 테스트")
+class ProductMonthlyRankingJobTest : IntegrationTest() {
+
+    @Autowired
+    private lateinit var jobLauncherTestUtils: JobLauncherTestUtils
+
+    @Autowired
+    @Qualifier(ProductMonthlyRankingJobConfig.JOB_NAME)
+    private lateinit var job: Job
+
+    @Autowired
+    private lateinit var weeklyRankingRepository: ProductWeeklyRankingRepository
+
+    @Autowired
+    private lateinit var monthlyRankingRepository: ProductMonthlyRankingRepository
+
+    private val monthPeriod = YearMonth.now()
+    private val monthStart = monthPeriod.atDay(1)
+
+    @BeforeEach
+    fun setUp() {
+        jobLauncherTestUtils.job = job
+    }
+
+    @Test
+    @DisplayName("전체 배치 흐름이 정상적으로 동작한다")
+    fun testCompleteJobExecution() {
+        // given: 10개 상품의 주간 랭킹 데이터 준비 (2주)
+        val week1Start = monthStart
+        val week1End = week1Start.plusDays(6)
+        val week2Start = week1End.plusDays(1)
+        val week2End = week2Start.plusDays(6)
+
+        val weeklyRankings = mutableListOf<ProductWeeklyRanking>()
+        (1L..10L).forEach { productId ->
+            weeklyRankings.add(
+                ProductWeeklyRanking.create(
+                    ranking = productId.toInt(),
+                    productId = productId,
+                    score = productId * 10.0,
+                    weekStart = week1Start,
+                    weekEnd = week1End,
+                ),
+            )
+            weeklyRankings.add(
+                ProductWeeklyRanking.create(
+                    ranking = productId.toInt(),
+                    productId = productId,
+                    score = productId * 5.0,
+                    weekStart = week2Start,
+                    weekEnd = week2End,
+                ),
+            )
+        }
+        weeklyRankingRepository.saveAll(weeklyRankings)
+
+        // when: Job 실행
+        val jobParameters = JobParametersBuilder()
+            .addString("yearMonth", monthPeriod.toString())
+            .addLong("timestamp", System.currentTimeMillis())
+            .toJobParameters()
+
+        val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)
+
+        // then: Job 성공
+        assertThat(jobExecution.status).isEqualTo(BatchStatus.COMPLETED)
+
+        val rankings = monthlyRankingRepository.findByMonthPeriod(monthPeriod)
+        assertThat(rankings).isNotEmpty
+        assertThat(rankings).hasSizeLessThanOrEqualTo(100)
+
+        rankings.forEach { ranking ->
+            assertThat(ranking.ranking).isGreaterThan(0)
+            assertThat(ranking.score).isGreaterThanOrEqualTo(0.0)
+        }
+
+        val sortedByRanking = rankings.sortedBy { it.ranking }
+        for (i in 0 until sortedByRanking.size - 1) {
+            assertThat(sortedByRanking[i].score).isGreaterThanOrEqualTo(sortedByRanking[i + 1].score)
+        }
+
+        val top1 = rankings.find { it.ranking == 1 }
+        assertThat(top1).isNotNull
+        assertThat(top1!!.productId).isEqualTo(10L)
+    }
+
+    @Test
+    @DisplayName("150개 상품 중 Top 100만 저장한다")
+    fun testSavesOnlyTop100() {
+        // given: 150개 상품 주간 랭킹 데이터
+        val weekStart = monthStart
+        val weekEnd = weekStart.plusDays(6)
+
+        val weeklyRankings = (1L..150L).map { productId ->
+            ProductWeeklyRanking.create(
+                ranking = productId.toInt(),
+                productId = productId,
+                score = (150 - productId).toDouble(),
+                weekStart = weekStart,
+                weekEnd = weekEnd,
+            )
+        }
+        weeklyRankingRepository.saveAll(weeklyRankings)
+
+        // when: Job 실행
+        val jobParameters = JobParametersBuilder()
+            .addString("yearMonth", monthPeriod.toString())
+            .addLong("timestamp", System.currentTimeMillis())
+            .toJobParameters()
+
+        val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)
+
+        // then
+        assertThat(jobExecution.status).isEqualTo(BatchStatus.COMPLETED)
+
+        val rankings = monthlyRankingRepository.findByMonthPeriod(monthPeriod)
+        assertThat(rankings).hasSize(100)
+
+        val top1 = rankings.find { it.ranking == 1 }
+        assertThat(top1).isNotNull
+        assertThat(top1!!.productId).isEqualTo(1L)
+
+        val excludedProducts = rankings.filter { it.productId > 100 }
+        assertThat(excludedProducts).isEmpty()
+    }
+
+    @Test
+    @DisplayName("여러 번 실행해도 Top 100만 유지된다")
+    fun testMultipleExecutionsKeepTop100() {
+        // given: 첫 번째 실행용 데이터 (50개)
+        val weekStart = monthStart
+        val weekEnd = weekStart.plusDays(6)
+
+        val firstBatch = (1L..50L).map { productId ->
+            ProductWeeklyRanking.create(
+                ranking = productId.toInt(),
+                productId = productId,
+                score = productId.toDouble(),
+                weekStart = weekStart,
+                weekEnd = weekEnd,
+            )
+        }
+        weeklyRankingRepository.saveAll(firstBatch)
+
+        // when: 첫 번째 Job 실행
+        val jobParameters1 = JobParametersBuilder()
+            .addString("yearMonth", monthPeriod.toString())
+            .addLong("timestamp", System.currentTimeMillis())
+            .toJobParameters()
+
+        val execution1 = jobLauncherTestUtils.launchJob(jobParameters1)
+        assertThat(execution1.status).isEqualTo(BatchStatus.COMPLETED)
+
+        // 추가 데이터 저장 (51~150)
+        val secondBatch = (51L..150L).map { productId ->
+            ProductWeeklyRanking.create(
+                ranking = productId.toInt(),
+                productId = productId,
+                score = (productId * 10).toDouble(),
+                weekStart = weekStart.plusDays(7),
+                weekEnd = weekEnd.plusDays(7),
+            )
+        }
+        weeklyRankingRepository.saveAll(secondBatch)
+
+        // when: 두 번째 Job 실행
+        val jobParameters2 = JobParametersBuilder()
+            .addString("yearMonth", monthPeriod.toString())
+            .addLong("timestamp", System.currentTimeMillis() + 1000)
+            .toJobParameters()
+
+        val execution2 = jobLauncherTestUtils.launchJob(jobParameters2)
+        assertThat(execution2.status).isEqualTo(BatchStatus.COMPLETED)
+
+        // then: 여전히 100개만 저장되어 있어야 함
+        val rankings = monthlyRankingRepository.findByMonthPeriod(monthPeriod)
+        assertThat(rankings).hasSize(100)
+
+        val top1 = rankings.find { it.ranking == 1 }
+        assertThat(top1!!.productId).isEqualTo(150L)
+    }
+
+    @Test
+    @DisplayName("데이터가 없을 때도 정상 종료된다")
+    fun testCompletesSuccessfullyWithNoData() {
+        // given: 데이터 없음
+
+        // when: Job 실행
+        val jobParameters = JobParametersBuilder()
+            .addString("yearMonth", monthPeriod.toString())
+            .addLong("timestamp", System.currentTimeMillis())
+            .toJobParameters()
+
+        val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)
+
+        // then: 정상 종료
+        assertThat(jobExecution.status).isEqualTo(BatchStatus.COMPLETED)
+
+        val rankings = monthlyRankingRepository.findByMonthPeriod(monthPeriod)
+        assertThat(rankings).isEmpty()
+    }
+
+    @Test
+    @DisplayName("monthPeriod가 정확하게 저장된다")
+    fun testStoresCorrectMonthPeriod() {
+        // given: 테스트 데이터
+        val weekStart = monthStart
+        val weekEnd = weekStart.plusDays(6)
+        weeklyRankingRepository.saveAll(
+            listOf(
+                ProductWeeklyRanking.create(
+                    ranking = 1,
+                    productId = 1L,
+                    score = 100.0,
+                    weekStart = weekStart,
+                    weekEnd = weekEnd,
+                ),
+            ),
+        )
+
+        // when: Job 실행
+        val jobParameters = JobParametersBuilder()
+            .addString("yearMonth", monthPeriod.toString())
+            .addLong("timestamp", System.currentTimeMillis())
+            .toJobParameters()
+
+        val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)
+
+        // then
+        assertThat(jobExecution.status).isEqualTo(BatchStatus.COMPLETED)
+
+        val rankings = monthlyRankingRepository.findByMonthPeriod(monthPeriod)
+        rankings.forEach { ranking ->
+            assertThat(ranking.monthPeriod).isEqualTo(monthPeriod)
+        }
+    }
+}

--- a/apps/commerce-batch/src/test/kotlin/com/loopers/batch/productmetrics/batch/ranking/ProductWeeklyRankingJobTest.kt
+++ b/apps/commerce-batch/src/test/kotlin/com/loopers/batch/productmetrics/batch/ranking/ProductWeeklyRankingJobTest.kt
@@ -1,0 +1,279 @@
+package com.loopers.batch.productmetrics.batch.ranking
+
+import com.loopers.IntegrationTest
+import com.loopers.batch.productmetrics.ranking.ProductWeeklyRankingJobConfig
+import com.loopers.domain.metrics.ProductMetrics
+import com.loopers.domain.ranking.ProductWeeklyRankingRepository
+import com.loopers.infrastructure.metrics.ProductMetricsJpaRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.batch.core.BatchStatus
+import org.springframework.batch.core.Job
+import org.springframework.batch.core.JobParametersBuilder
+import org.springframework.batch.test.JobLauncherTestUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import java.time.LocalDate
+
+@DisplayName("ProductWeeklyRankingJob 통합 테스트")
+class ProductWeeklyRankingJobTest : IntegrationTest() {
+
+    @Autowired
+    private lateinit var jobLauncherTestUtils: JobLauncherTestUtils
+
+    @Autowired
+    @Qualifier(ProductWeeklyRankingJobConfig.JOB_NAME)
+    private lateinit var job: Job
+
+    @Autowired
+    private lateinit var productMetricsJpaRepository: ProductMetricsJpaRepository
+
+    @Autowired
+    private lateinit var rankingRepository: ProductWeeklyRankingRepository
+
+    private val weekEnd = LocalDate.now().minusDays(1)
+    private val weekStart = weekEnd.minusDays(6)
+
+    @BeforeEach
+    fun setUp() {
+        jobLauncherTestUtils.job = job
+    }
+
+    @Test
+    @DisplayName("전체 배치 흐름이 정상적으로 동작한다")
+    fun testCompleteJobExecution() {
+        // given: 10개 상품의 주간 데이터 준비
+        val yesterday = LocalDate.now().minusDays(1)
+
+        (1L..10L).forEach { productId ->
+            (0..6).forEach { daysAgo ->
+                val date = yesterday.minusDays(daysAgo.toLong())
+                if (date in weekStart..weekEnd) {
+                    val metrics = ProductMetrics.create(productId, date)
+                    metrics.viewCount = (productId * 10)
+                    metrics.likeCount = productId
+                    metrics.soldCount = (productId / 2)
+                    productMetricsJpaRepository.save(metrics)
+                }
+            }
+        }
+
+        // when: Job 실행
+        val jobParameters = JobParametersBuilder()
+            .addString("weekStart", weekStart.toString())
+            .addString("weekEnd", weekEnd.toString())
+            .addLong("timestamp", System.currentTimeMillis()) // 고유성 보장
+            .toJobParameters()
+
+        val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)
+
+        // then: Job 성공
+        assertThat(jobExecution.status).isEqualTo(BatchStatus.COMPLETED)
+
+        // 랭킹 데이터 검증
+        val rankings = rankingRepository.findByWeekStartAndWeekEnd(weekStart, weekEnd)
+        assertThat(rankings).isNotEmpty
+        assertThat(rankings).hasSizeLessThanOrEqualTo(100)
+
+        // 순위가 정상적으로 매겨졌는지 확인
+        rankings.forEach { ranking ->
+            assertThat(ranking.ranking).isGreaterThan(0)
+            assertThat(ranking.score).isGreaterThanOrEqualTo(0.0)
+        }
+
+        // 순위가 점수 내림차순인지 확인
+        val sortedByRanking = rankings.sortedBy { it.ranking }
+        for (i in 0 until sortedByRanking.size - 1) {
+            assertThat(sortedByRanking[i].score).isGreaterThanOrEqualTo(sortedByRanking[i + 1].score)
+        }
+    }
+
+    @Test
+    @DisplayName("150개 상품 중 Top 100만 저장한다")
+    fun testSavesOnlyTop100() {
+        // given: 150개 상품 데이터
+        val yesterday = LocalDate.now().minusDays(1)
+
+        (1L..150L).forEach { productId ->
+            val metrics = ProductMetrics.create(productId, yesterday)
+            metrics.viewCount = ((150 - productId) * 100)
+            metrics.likeCount = (150 - productId)
+            metrics.soldCount = ((150 - productId) / 10)
+            productMetricsJpaRepository.save(metrics)
+        }
+
+        // when: Job 실행
+        val jobParameters = JobParametersBuilder()
+            .addString("weekStart", weekStart.toString())
+            .addString("weekEnd", weekEnd.toString())
+            .addLong("timestamp", System.currentTimeMillis())
+            .toJobParameters()
+
+        val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)
+
+        // then
+        assertThat(jobExecution.status).isEqualTo(BatchStatus.COMPLETED)
+
+        val rankings = rankingRepository.findByWeekStartAndWeekEnd(weekStart, weekEnd)
+        assertThat(rankings).hasSize(100)
+
+        // 1위는 productId=1 (가장 높은 점수)
+        val top1 = rankings.find { it.ranking == 1 }
+        assertThat(top1).isNotNull
+        assertThat(top1!!.productId).isEqualTo(1L)
+
+        // productId 101~150은 저장되지 않아야 함
+        val excludedProducts = rankings.filter { it.productId > 100 }
+        assertThat(excludedProducts).isEmpty()
+    }
+
+    @Test
+    @DisplayName("여러 번 실행해도 Top 100만 유지된다")
+    fun testMultipleExecutionsKeepTop100() {
+        // given: 첫 번째 실행용 데이터 (50개)
+        val yesterday = LocalDate.now().minusDays(1)
+
+        (1L..50L).forEach { productId ->
+            val metrics = ProductMetrics.create(productId, yesterday)
+            metrics.viewCount = (productId * 100)
+            metrics.likeCount = productId
+            metrics.soldCount = (productId / 10)
+            productMetricsJpaRepository.save(metrics)
+        }
+
+        // when: 첫 번째 Job 실행
+        val jobParameters1 = JobParametersBuilder()
+            .addString("weekStart", weekStart.toString())
+            .addString("weekEnd", weekEnd.toString())
+            .addLong("timestamp", System.currentTimeMillis())
+            .toJobParameters()
+
+        val execution1 = jobLauncherTestUtils.launchJob(jobParameters1)
+        assertThat(execution1.status).isEqualTo(BatchStatus.COMPLETED)
+
+        // 추가 데이터 저장 (51~150)
+        (51L..150L).forEach { productId ->
+            val metrics = ProductMetrics.create(productId, yesterday)
+            metrics.viewCount = (productId * 100)
+            metrics.likeCount = productId
+            metrics.soldCount = (productId / 10)
+            productMetricsJpaRepository.save(metrics)
+        }
+
+        // when: 두 번째 Job 실행
+        val jobParameters2 = JobParametersBuilder()
+            .addString("weekStart", weekStart.toString())
+            .addString("weekEnd", weekEnd.toString())
+            .addLong("timestamp", System.currentTimeMillis() + 1000)
+            .toJobParameters()
+
+        val execution2 = jobLauncherTestUtils.launchJob(jobParameters2)
+        assertThat(execution2.status).isEqualTo(BatchStatus.COMPLETED)
+
+        // then: 여전히 100개만 저장되어 있어야 함
+        val rankings = rankingRepository.findByWeekStartAndWeekEnd(weekStart, weekEnd)
+        assertThat(rankings).hasSize(100)
+
+        // Top 100은 productId 51~150 중에서 선택되어야 함 (점수가 더 높으므로)
+        val top1 = rankings.find { it.ranking == 1 }
+        assertThat(top1!!.productId).isEqualTo(150L) // 가장 높은 점수
+    }
+
+    @Test
+    @DisplayName("날짜별 감쇠 가중치가 적용된다")
+    fun testAppliesDecayWeights() {
+        // given: 같은 상품의 어제 데이터와 7일 전 데이터
+        val productId = 1L
+        val yesterday = LocalDate.now().minusDays(1)
+        val sevenDaysAgo = LocalDate.now().minusDays(7)
+
+        // 어제 데이터 (감쇠 가중치 1.0)
+        val metricsYesterday = ProductMetrics.create(productId, yesterday)
+        metricsYesterday.viewCount = 100
+        metricsYesterday.likeCount = 10
+        metricsYesterday.soldCount = 5
+        productMetricsJpaRepository.save(metricsYesterday)
+
+        // 7일 전 데이터 (감쇠 가중치 0.1) - 같은 메트릭 값
+        val metricsSevenDays = ProductMetrics.create(productId + 1, sevenDaysAgo)
+        metricsSevenDays.viewCount = 100
+        metricsSevenDays.likeCount = 10
+        metricsSevenDays.soldCount = 5
+        productMetricsJpaRepository.save(metricsSevenDays)
+
+        // when: Job 실행
+        val jobParameters = JobParametersBuilder()
+            .addString("weekStart", weekStart.toString())
+            .addString("weekEnd", weekEnd.toString())
+            .addLong("timestamp", System.currentTimeMillis())
+            .toJobParameters()
+
+        val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)
+
+        // then
+        assertThat(jobExecution.status).isEqualTo(BatchStatus.COMPLETED)
+
+        val rankings = rankingRepository.findByWeekStartAndWeekEnd(weekStart, weekEnd)
+        val yesterdayRanking = rankings.find { it.productId == productId }
+        val sevenDaysRanking = rankings.find { it.productId == productId + 1 }
+
+        // 어제 데이터의 점수가 7일 전 데이터보다 높아야 함
+        if (yesterdayRanking != null && sevenDaysRanking != null) {
+            assertThat(yesterdayRanking.score).isGreaterThan(sevenDaysRanking.score)
+        }
+    }
+
+    @Test
+    @DisplayName("데이터가 없을 때도 정상 종료된다")
+    fun testCompletesSuccessfullyWithNoData() {
+        // given: 데이터 없음
+
+        // when: Job 실행
+        val jobParameters = JobParametersBuilder()
+            .addString("weekStart", weekStart.toString())
+            .addString("weekEnd", weekEnd.toString())
+            .addLong("timestamp", System.currentTimeMillis())
+            .toJobParameters()
+
+        val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)
+
+        // then: 정상 종료
+        assertThat(jobExecution.status).isEqualTo(BatchStatus.COMPLETED)
+
+        // 랭킹 데이터 없음
+        val rankings = rankingRepository.findByWeekStartAndWeekEnd(weekStart, weekEnd)
+        assertThat(rankings).isEmpty()
+    }
+
+    @Test
+    @DisplayName("weekStart와 weekEnd가 정확하게 저장된다")
+    fun testStoresCorrectWeekRange() {
+        // given: 테스트 데이터
+        val yesterday = LocalDate.now().minusDays(1)
+        val metrics = ProductMetrics.create(1L, yesterday)
+        metrics.viewCount = 100
+        metrics.likeCount = 10
+        metrics.soldCount = 5
+        productMetricsJpaRepository.save(metrics)
+
+        // when: Job 실행
+        val jobParameters = JobParametersBuilder()
+            .addString("weekStart", weekStart.toString())
+            .addString("weekEnd", weekEnd.toString())
+            .addLong("timestamp", System.currentTimeMillis())
+            .toJobParameters()
+
+        val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)
+
+        // then
+        assertThat(jobExecution.status).isEqualTo(BatchStatus.COMPLETED)
+
+        val rankings = rankingRepository.findByWeekStartAndWeekEnd(weekStart, weekEnd)
+        rankings.forEach { ranking ->
+            assertThat(ranking.weekStart).isEqualTo(weekStart)
+            assertThat(ranking.weekEnd).isEqualTo(weekEnd)
+        }
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/metrics/ProductMetrics.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/metrics/ProductMetrics.kt
@@ -1,26 +1,33 @@
 package com.loopers.domain.metrics
 
 import jakarta.persistence.Column
+import jakarta.persistence.EmbeddedId
 import jakarta.persistence.Entity
-import jakarta.persistence.Id
+import jakarta.persistence.Index
 import jakarta.persistence.Table
 import jakarta.persistence.Version
+import java.time.LocalDate
 import java.time.ZonedDateTime
 
 /**
- * 상품 메트릭 집계 테이블
+ * 상품 메트릭 집계 테이블 (일자별 이력 관리)
  *
- * Kafka 이벤트를 통해 수집된 상품 관련 메트릭을 집계
+ * Kafka 이벤트를 통해 수집된 상품 관련 메트릭을 일자별로 집계
  * - 좋아요 수
  * - 조회 수
  * - 판매 수량
  */
 @Entity
-@Table(name = "product_metrics")
+@Table(
+    name = "product_metrics",
+    indexes = [
+        Index(name = "idx_metric_date", columnList = "metric_date"),
+        Index(name = "idx_product_id", columnList = "product_id"),
+    ],
+)
 class ProductMetrics(
-    @Id
-    @Column(name = "product_id")
-    val productId: Long,
+    @EmbeddedId
+    val id: ProductMetricsId,
 
     @Column(name = "like_count", nullable = false)
     var likeCount: Long = 0,
@@ -68,9 +75,9 @@ class ProductMetrics(
     }
 
     companion object {
-        fun create(productId: Long): ProductMetrics {
+        fun create(productId: Long, metricDate: LocalDate): ProductMetrics {
             return ProductMetrics(
-                productId = productId,
+                id = ProductMetricsId(productId, metricDate),
                 likeCount = 0,
                 viewCount = 0,
                 soldCount = 0,

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/metrics/ProductMetricsId.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/metrics/ProductMetricsId.kt
@@ -1,0 +1,21 @@
+package com.loopers.domain.metrics
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import java.io.Serializable
+import java.time.LocalDate
+
+/**
+ * ProductMetrics 복합키
+ *
+ * @property productId 상품 ID
+ * @property metricDate 메트릭 집계 일자
+ */
+@Embeddable
+data class ProductMetricsId(
+    @Column(name = "product_id", nullable = false)
+    val productId: Long,
+
+    @Column(name = "metric_date", nullable = false)
+    val metricDate: LocalDate,
+) : Serializable

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/metrics/ProductMetricsRepository.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/metrics/ProductMetricsRepository.kt
@@ -1,7 +1,14 @@
 package com.loopers.domain.metrics
 
+import java.time.LocalDate
+
 interface ProductMetricsRepository {
-    fun findByProductId(productId: Long): ProductMetrics?
-    fun findByProductIdWithLock(productId: Long): ProductMetrics?
+    fun findByProductIdAndMetricDate(productId: Long, metricDate: LocalDate): ProductMetrics?
+    fun findByProductIdAndMetricDateWithLock(productId: Long, metricDate: LocalDate): ProductMetrics?
     fun save(productMetrics: ProductMetrics): ProductMetrics
+    fun findByProductIdAndMetricDateBetween(
+        productId: Long,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<ProductMetrics>
 }

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.kt
@@ -1,13 +1,23 @@
 package com.loopers.infrastructure.metrics
 
 import com.loopers.domain.metrics.ProductMetrics
+import com.loopers.domain.metrics.ProductMetricsId
 import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
+import java.time.LocalDate
 
-interface ProductMetricsJpaRepository : JpaRepository<ProductMetrics, Long> {
+interface ProductMetricsJpaRepository : JpaRepository<ProductMetrics, ProductMetricsId> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT pm FROM ProductMetrics pm WHERE pm.productId = :productId")
-    fun findByProductIdWithLock(productId: Long): ProductMetrics?
+    @Query("SELECT pm FROM ProductMetrics pm WHERE pm.id.productId = :productId AND pm.id.metricDate = :metricDate")
+    fun findByProductIdAndMetricDateWithLock(productId: Long, metricDate: LocalDate): ProductMetrics?
+
+    fun findByIdProductIdAndIdMetricDate(productId: Long, metricDate: LocalDate): ProductMetrics?
+
+    fun findByIdProductIdAndIdMetricDateBetween(
+        productId: Long,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<ProductMetrics>
 }

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.kt
@@ -2,23 +2,35 @@ package com.loopers.infrastructure.metrics
 
 import com.loopers.domain.metrics.ProductMetrics
 import com.loopers.domain.metrics.ProductMetricsRepository
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 
 @Repository
 class ProductMetricsRepositoryImpl(
     private val productMetricsJpaRepository: ProductMetricsJpaRepository,
 ) : ProductMetricsRepository {
 
-    override fun findByProductId(productId: Long): ProductMetrics? {
-        return productMetricsJpaRepository.findByIdOrNull(productId)
+    override fun findByProductIdAndMetricDate(productId: Long, metricDate: LocalDate): ProductMetrics? {
+        return productMetricsJpaRepository.findByIdProductIdAndIdMetricDate(productId, metricDate)
     }
 
-    override fun findByProductIdWithLock(productId: Long): ProductMetrics? {
-        return productMetricsJpaRepository.findByProductIdWithLock(productId)
+    override fun findByProductIdAndMetricDateWithLock(productId: Long, metricDate: LocalDate): ProductMetrics? {
+        return productMetricsJpaRepository.findByProductIdAndMetricDateWithLock(productId, metricDate)
     }
 
     override fun save(productMetrics: ProductMetrics): ProductMetrics {
         return productMetricsJpaRepository.save(productMetrics)
+    }
+
+    override fun findByProductIdAndMetricDateBetween(
+        productId: Long,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<ProductMetrics> {
+        return productMetricsJpaRepository.findByIdProductIdAndIdMetricDateBetween(
+            productId,
+            startDate,
+            endDate,
+        )
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "loopers-ecommerce"
 include(
     ":apps:commerce-api",
     ":apps:commerce-streamer",
+    ":apps:commerce-batch",
     ":apps:pg-simulator",
     ":modules:jpa",
     ":modules:redis",


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->
  Spring Batch를 활용한 주간/월간 상품 랭킹 시스템을 구축했습니다. 기존 product_metrics 일간 집계 데이터를 기반으로 주간/월간 랭킹을 배치로 집계하고, Materialized View에 저장하여 조회 성능을 최적화했습니다.

주요 변경사항:
  - commerce-batch 앱 신규 추가 (Spring Batch 전용 애플리케이션)
  - 주간/월간 상품 랭킹 배치 Job 구현 (Chunk-Oriented Processing)
  - Materialized View 설계 (mv_product_rank_weekly, mv_product_rank_monthly)
  - Ranking API 확장 (일간/주간/월간 랭킹 통합 조회)
  - 배치 실행 REST API 제공 (/api/v1/batch/weekly-ranking, /api/v1/batch/monthly-ranking)

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
-->

1. 주간 랭킹 / 월간 랭킹 batch job 로직이 적절한지 리뷰 받고 싶습니다. 
- 아쉬운 점은 없는지, 대용량 환경에서 문제점은 없는지..
- Writer에서 데이터를 누적하면 OOM이 발생할 수 있어 임시 테이블에 적재 후 TOP 100 랭킹을 구하는 방법을 채택하였습니다.

**ProductWeeklyRankingJob (주간 랭킹)**
```
  Reader: product_metrics 테이블에서 주간 데이터를 날짜별로 분리하여 집계
  - GROUP BY product_id, days_from_end (days_from_end: 주 종료일로부터 며칠 전인지 0~6)
  - 같은 상품이 7일치 데이터가 있으면 7개의 레코드로 반환

  Processor: 날짜별 감쇠 가중치 적용
  - 기본 점수 = 조회수×1 + 주문수×10 + 좋아요×5
  - 날짜별 가중치: D+0(최근) 1.0 → D+1: 0.9 → D+2: 0.8 → ... → D+6(오래됨) 0.1
  - 최종 점수 = 기본 점수 × 감쇠 가중치

  Writer: 임시 테이블(temp_weekly_ranking)에서 점수 합산 후 Top 100 저장
  - 청크 단위로 임시 테이블에 INSERT (중복 시 점수 합산)
  - AfterStep에서 점수순 정렬 후 Top 100 추출
  - 동일 주차 데이터 삭제 후 재적재 (멱등성 확보)
```

**ProductMonthlyRankingJob (월간 랭킹)**
```
  Reader: product_metrics 테이블에서 월간 데이터를 전체 합산하여 집계
  - GROUP BY product_id (날짜 구분 없이 월 전체를 하나로)

  Processor: 단순 가중치 적용
  - 최종 점수 = 총 조회수×1 + 총 주문수×10 + 총 좋아요×5
  - 날짜별 감쇠 가중치 없음

  Writer: 임시 테이블(temp_monthly_ranking)에서 Top 100 저장
  - 주간 랭킹과 동일한 방식
  - 동일 월 데이터 삭제 후 재적재 (멱등성 확보)
```

2. chunk size와 페이징 size 선정 기준
- Chunk Size를 어떤 기준으로 설정하시는지 궁금합니다.
- Reader에서 Paging으로 처리할 경우 pageSize와 chunk size를 동일하게 구성하는지 궁금합니다
- 배치 job을 실행할 서버(혹은 로컬)의 메모리 사이즈보다 적은 값을 찾아서 실행 하면 될까요?

3. 월간 랭킹 집계 방법
- product_metric를 1일 ~ 말일 조건으로 풀스캔하여 월간 랭킹 집계를 만들었습니다.
- 문득, 집계한 주간 랭킹 TOP 100으로 월간 랭킹 집계를 만들어도 되지 않을까 생각해봤습니다.
- 이러한 고민은 개발자가 아닌 PO 선택 사항 인걸까요? 리뷰어님은 어떤 방법을 선호하시는지 궁금합니다.
- 주간 랭킹 집계로 만들 경우 아래와 같은 케이스가 발생할 수 있을 것 같습니다.
```
  - ❌ 데이터 손실 위험: 주간 101위 이하 상품은 월간 집계에서 제외됨
  예시:
  - 상품 A: 1주차 101위, 2주차 101위, 3주차 101위, 4주차 101위
    → 매주 꾸준히 상위권이었지만 주간 Top 100 밖이라 월간 랭킹에서 누락
  - 상품 B: 1주차 5위, 나머지 주는 활동 없음
    → 월간으로는 A가 더 높아야 하지만 B만 포함됨
```

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->
### 🧱 Spring Batch

- [x]  Spring Batch Job 을 작성하고, 파라미터 기반으로 동작시킬 수 있다.
- [x]  Chunk Oriented Processing (Reader/Processor/Writer or Tasklet) 기반의 배치 처리를 구현했다.
- [x]  집계 결과를 저장할 Materialized View 의 구조를 설계하고 올바르게 적재했다.

### 🧩 Ranking API

- [x]  API 가 일간, 주간, 월간 랭킹을 제공하며 조회해야 하는 형태에 따라 적절한 데이터를 기반으로 랭킹을 제공한다.


## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 랭킹 조회에 period 파라미터 추가: daily/weekly/monthly 선택 가능
  * 배치 앱 추가 및 배치 API 제공: 주간/월간 랭킹 수동 실행 가능

* **Chores**
  * 배치 파이프라인 도입: 주/월 단위 집계, 점수 산출, Top100 저장 워크플로 추가
  * 데이터 모델 및 변환기 보강: 주/월 기간 처리 지원

* **Tests**
  * 통합·배치 테스트 보강: 주간/월간 시나리오 및 Top100 검증 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->